### PR TITLE
Support async prompt functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ LLM-powered functions created using `@prompt` and `@prompt_chain` can be supplie
 
 ### Additional Features
 
+- The `@prompt` decorator can also be used with `async` function definitions.
 - The docstring of the decorated function will be used as the prompt template if the `template` argument is not provided to `@prompt`/`@prompt_chain`.
 - The `Annotated` type annotation can be used to provide descriptions and other metadata for function parameters. See [the pydantic documentation on using `Field` to describe function arguments](https://docs.pydantic.dev/latest/usage/validation_decorator/#using-field-to-describe-function-arguments).
 - The `@prompt` and `@prompt_chain` decorators also accept a `model` argument. You can pass an instance of `OpenaiChatModel` (from `magentic.chat_model.openai_chat_model`) to use GPT4 or configure a different temperature.

--- a/examples/quiz/quiz_async.py
+++ b/examples/quiz/quiz_async.py
@@ -76,16 +76,6 @@ async def generate_question(topic: str, difficulty: int) -> Question:
     ...
 
 
-async def generate_questions(topic: str, num_questions: int) -> list[Question]:
-    """Generates a list of questions of increasing difficulty."""
-    return await asyncio.gather(
-        *(
-            generate_question(topic, difficulty=max(num + 1, 5))
-            for num in range(num_questions)
-        )
-    )
-
-
 @prompt("""Return true if the user's answer is correct.
 Question: {question.question}
 Answer: {question.answer}
@@ -105,7 +95,13 @@ def create_encouragement_message(score: int, topic: str) -> str:
 async def main() -> None:
     topic = input("Enter a topic for a quiz: ")
     num_questions = int(input("Enter the number of questions: "))
-    questions = await generate_questions(topic, num_questions)
+    # Generate questions concurrently
+    questions = await asyncio.gather(
+        *(
+            generate_question(topic, difficulty=max(num + 1, 5))
+            for num in range(num_questions)
+        )
+    )
 
     user_points = 0
     for num, question in enumerate(questions, start=1):

--- a/examples/quiz/quiz_async.py
+++ b/examples/quiz/quiz_async.py
@@ -1,0 +1,127 @@
+"""A simple quiz game.
+
+This example builds on the `quiz.py` example to demonstrate how using asyncio can greatly speed up queries. The quiz
+questions are now generated concurrently which means the quiz starts much more quickly after the user has entered the
+topic and number of questions. However since the questions are generated independently there is more likelihood of
+duplicates - increasing the model temperature can help with this.
+
+---
+
+Run this example within this directory with:
+
+```sh
+poetry run python quiz.py
+```
+
+or if you have installed magentic with pip:
+
+```sh
+python quiz.py
+```
+
+---
+
+Example run:
+
+```
+% poetry run python examples/quiz/quiz_async.py
+Enter a topic for a quiz: France
+Enter the number of questions: 3
+
+1 / 3
+Q: Which French king was known as the 'Sun King'?
+A: Louis XI
+Incorrect! The correct answer is: Louis XIV
+
+2 / 3
+Q: What is the capital city of France?
+A: Paris
+Correct! The answer is: Paris
+
+3 / 3
+Q: What is the official motto of France?
+A: Bonjour!
+Incorrect! The correct answer is: Liberty, Equality, Fraternity
+
+Quiz complete! You scored: 33%
+
+Congratulations on your impressive score of 33/100 on the France quiz! Who needs to know about the Eiffel Tower or
+ croissants when you can rock the world with your unique knowledge? Keep shining bright, my friend, and remember,
+ there's always room for improvement...unless we're talking about French pastries, then there's never enough room!
+ Keep up the great work!
+```
+
+"""
+
+
+import asyncio
+
+from pydantic import BaseModel
+
+from magentic import prompt
+from magentic.chat_model.openai_chat_model import OpenaiChatModel
+
+
+class Question(BaseModel):
+    question: str
+    answer: str
+
+
+@prompt(
+    "Generate a quiz question about {topic} with difficulty {difficulty}/5.",
+    # Increase temperature to try generate unique questions
+    model=OpenaiChatModel(temperature=1),
+)
+async def generate_question(topic: str, difficulty: int) -> Question:
+    ...
+
+
+async def generate_questions(topic: str, num_questions: int) -> list[Question]:
+    """Generates a list of questions of increasing difficulty."""
+    return await asyncio.gather(
+        *(
+            generate_question(topic, difficulty=max(num + 1, 5))
+            for num in range(num_questions)
+        )
+    )
+
+
+@prompt("""Return true if the user's answer is correct.
+Question: {question.question}
+Answer: {question.answer}
+User Answer: {user_answer}""")
+def is_answer_correct(question: Question, user_answer: str) -> bool:
+    ...
+
+
+@prompt(
+    "Create a short and funny message of celebration or encouragment for someone who"
+    " scored {score}/100 on a quiz about {topic}."
+)
+def create_encouragement_message(score: int, topic: str) -> str:
+    ...
+
+
+async def main() -> None:
+    topic = input("Enter a topic for a quiz: ")
+    num_questions = int(input("Enter the number of questions: "))
+    questions = await generate_questions(topic, num_questions)
+
+    user_points = 0
+    for num, question in enumerate(questions, start=1):
+        print(f"\n{num} / {len(questions)}")
+        print(f"Q: {question.question}")
+        user_answer = input("A: ")
+
+        if is_answer_correct(question, user_answer):
+            print(f"Correct! The answer is: {question.answer}")
+            user_points += 1
+        else:
+            print(f"Incorrect! The correct answer is: {question.answer}")
+
+    score = 100 * user_points // len(questions)
+    print(f"\nQuiz complete! You scored: {score}%\n")
+    print(create_encouragement_message(score, topic))
+
+
+asyncio.run(main())

--- a/poetry.lock
+++ b/poetry.lock
@@ -2172,6 +2172,24 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.21.1"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-asyncio-0.21.1.tar.gz", hash = "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d"},
+    {file = "pytest_asyncio-0.21.1-py3-none-any.whl", hash = "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
 name = "pytest-clarity"
 version = "1.0.1"
 description = "A plugin providing an alternative, colourful diff output for failing assertions."
@@ -3014,4 +3032,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "311763e3e51fcb16d48d97e9aa1eb62c97b0f196454c6159ab7395653f91b2db"
+content-hash = "6ad254b5ba4fe3cae7376c55865874f824d466170007a720e6a13279733987a0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ black = "*"
 isort = "*"
 mypy = "*"
 pytest = "*"
+pytest-asyncio = "*"
 pytest-clarity = "*"
 pytest-cov = "*"
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -285,6 +285,7 @@ class OpenaiChatModel:
 
         return AssistantMessage(response_message["content"])
 
+    # TODO: Deduplicate this and `complete`
     async def acomplete(
         self,
         messages: Iterable[Message[Any]],

--- a/src/magentic/prompt_chain.py
+++ b/src/magentic/prompt_chain.py
@@ -1,6 +1,6 @@
 import inspect
 from functools import update_wrapper
-from typing import Any, Callable, ParamSpec, TypeVar
+from typing import Any, Callable, ParamSpec, TypeVar, cast
 
 from magentic.chat import Chat
 from magentic.chat_model.base import FunctionCallMessage
@@ -38,7 +38,7 @@ def prompt_chain(
             while isinstance(chat.messages[-1], FunctionCallMessage):
                 function_result_message = chat.messages[-1].get_result()
                 chat = chat.add_message(function_result_message).submit()
-            return chat.messages[-1].content  # type: ignore[no-any-return]
+            return cast(R, chat.messages[-1].content)
 
         return update_wrapper(wrapper, func)
 

--- a/src/magentic/prompt_function.py
+++ b/src/magentic/prompt_function.py
@@ -82,7 +82,7 @@ class PromptFunction(BasePromptFunction[P, R], Generic[P, R]):
             functions=self._functions,
             output_types=self._return_types,
         )
-        return message.content  # type: ignore[return-value]
+        return cast(R, message.content)
 
 
 class AsyncPromptFunction(BasePromptFunction[P, R], Generic[P, R]):
@@ -98,7 +98,7 @@ class AsyncPromptFunction(BasePromptFunction[P, R], Generic[P, R]):
             functions=self._functions,
             output_types=self._return_types,
         )
-        return message.content  # type: ignore[return-value]
+        return cast(R, message.content)
 
 
 class PromptDecorator(Protocol):

--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -106,8 +106,6 @@ def test_decorator_return_function_call():
     assert isinstance(output, FunctionCall)
     func_result = output()
     assert isinstance(func_result, int)
-    assert isinstance(func_result, int)
-    assert isinstance(func_result, int)
 
 
 @pytest.mark.asyncio
@@ -120,3 +118,20 @@ async def test_async_decorator_return_str():
 
     assert isinstance(get_capital, AsyncPromptFunction)
     assert await get_capital("Ireland") == "Dublin"
+
+
+@pytest.mark.asyncio
+@pytest.mark.openai
+async def test_async_decorator_return_function_call():
+    def plus(a: int, b: int) -> int:
+        return a + b
+
+    @prompt(functions=[plus])
+    async def sum_populations(country_one: str, country_two: str) -> FunctionCall[int]:
+        """Sum the populations of {country_one} and {country_two}."""
+        ...
+
+    output = await sum_populations("Ireland", "UK")
+    assert isinstance(output, FunctionCall)
+    func_result = output()
+    assert isinstance(func_result, int)

--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import BaseModel
 
 from magentic.function_call import FunctionCall
-from magentic.prompt_function import PromptFunction, prompt
+from magentic.prompt_function import AsyncPromptFunction, PromptFunction, prompt
 
 
 @pytest.mark.openai
@@ -108,3 +108,15 @@ def test_decorator_return_function_call():
     assert isinstance(func_result, int)
     assert isinstance(func_result, int)
     assert isinstance(func_result, int)
+
+
+@pytest.mark.asyncio
+@pytest.mark.openai
+async def test_async_decorator_return_str():
+    @prompt()
+    async def get_capital(country: str) -> str:
+        """What is the capital of {country}? Name only. No punctuation."""
+        ...
+
+    assert isinstance(get_capital, AsyncPromptFunction)
+    assert await get_capital("Ireland") == "Dublin"


### PR DESCRIPTION
Enable the `@prompt` decorator to work with `async` functions.

To enable this, add an `AsyncPromptFunction` class and the `OpenaiChatModel.acomplete` method. Add `async_quiz.py` example to demonstrate why this is useful.

This PR does not add support for async FunctionCalls.

Also, replace some type ignore comments with `cast`
