### PR TITLE
Remove ability to use function docstring as template

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ def activate_oven(temperature: int, mode: Literal["broil", "bake", "roast"]) -> 
 
 
 @prompt(
-    template="Prepare the oven so I can make {food}",
+    "Prepare the oven so I can make {food}",
     functions=[activate_oven],
 )
 def configure_oven(food: str) -> FunctionCall[str]:
@@ -101,7 +101,7 @@ def get_current_weather(location, unit="fahrenheit"):
 
 
 @prompt_chain(
-    template="What's the weather like in {city}?",
+    "What's the weather like in {city}?",
     functions=[get_current_weather],
 )
 def describe_weather(city: str) -> str:

--- a/README.md
+++ b/README.md
@@ -133,14 +133,13 @@ Many type checkers will raise warnings or errors for functions with the `prompt`
    ```
 1. Make the function body `...` (this does not satisfy mypy) or `raise`.
    ```python
-   @prompt()
+   @prompt("Choose a color")
    def random_color() -> str:
-       """Choose a color"""
        ...
    ```
-1. Use comment `# type: ignore[empty-body]` on each function.
+1. Use comment `# type: ignore[empty-body]` on each function. In this case you can add a docstring instead of `...`.
    ```python
-   @prompt()
+   @prompt("Choose a color")
    def random_color() -> str:  # type: ignore[empty-body]
-       """Choose a color"""
+       """Returns a random color."""
    ```

--- a/src/magentic/prompt_chain.py
+++ b/src/magentic/prompt_chain.py
@@ -12,21 +12,16 @@ R = TypeVar("R")
 
 
 def prompt_chain(
-    template: str | None = None,
+    template: str,
     functions: list[Callable[..., Any]] | None = None,
     model: OpenaiChatModel | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Converts a Python function to an LLM query, auto-resolving function calls."""
 
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
-        if (_template := template or inspect.getdoc(func)) is None:
-            raise ValueError(
-                "`template` argument must be provided if function has no docstring"
-            )
-
         func_signature = inspect.signature(func)
         prompt_function = PromptFunction[P, R](
-            template=_template,
+            template=template,
             parameters=list(func_signature.parameters.values()),
             return_type=func_signature.return_annotation,
             functions=functions,

--- a/src/magentic/prompt_function.py
+++ b/src/magentic/prompt_function.py
@@ -114,22 +114,18 @@ class PromptDecorator(Protocol):
 
 
 def prompt(
-    template: str | None = None,
+    template: str,
     functions: list[Callable[..., Any]] | None = None,
     model: OpenaiChatModel | None = None,
 ) -> PromptDecorator:
     def decorator(
         func: Callable[P, Awaitable[R]] | Callable[P, R]
     ) -> AsyncPromptFunction[P, R] | PromptFunction[P, R]:
-        if (_template := template or inspect.getdoc(func)) is None:
-            raise ValueError(
-                "`template` argument must be provided if function has no docstring"
-            )
         func_signature = inspect.signature(func)
 
         if inspect.iscoroutinefunction(func):
             async_prompt_function = AsyncPromptFunction[P, R](
-                template=_template,
+                template=template,
                 parameters=list(func_signature.parameters.values()),
                 return_type=func_signature.return_annotation,
                 functions=functions,
@@ -139,7 +135,7 @@ def prompt(
             return cast(AsyncPromptFunction[P, R], async_prompt_function)  # type: ignore[redundant-cast]
 
         prompt_function = PromptFunction[P, R](
-            template=_template,
+            template=template,
             parameters=list(func_signature.parameters.values()),
             return_type=func_signature.return_annotation,
             functions=functions,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -11,9 +11,8 @@ def test_chat_from_prompt():
     def plus(a: int, b: int) -> int:
         return a + b
 
-    @prompt(functions=[plus])
+    @prompt("What is {a} plus {b}?", functions=[plus])
     def add_text_numbers(a: str, b: str) -> int:
-        """What is {a} plus {b}?"""
         ...
 
     chat = Chat.from_prompt(add_text_numbers, "one", "two")

--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -11,17 +11,7 @@ from magentic.prompt_function import AsyncPromptFunction, PromptFunction, prompt
 
 @pytest.mark.openai
 def test_decorator_return_str():
-    @prompt()
-    def get_capital(country: str) -> str:
-        """What is the capital of {country}? Name only. No punctuation."""
-        ...
-
-    assert get_capital("Ireland") == "Dublin"
-
-
-@pytest.mark.openai
-def test_decorator_template_with_docstring():
-    @prompt(template="What is the capital of {country}? Name only. No punctuation.")
+    @prompt("What is the capital of {country}? Name only. No punctuation.")
     def get_capital(country: str) -> str:
         """This is the docstring."""
         ...
@@ -33,9 +23,8 @@ def test_decorator_template_with_docstring():
 
 @pytest.mark.openai
 def test_decorator_return_bool():
-    @prompt()
+    @prompt("True if {capital} is the capital of {country}.")
     def is_capital(capital: str, country: str) -> bool:
-        """True if {capital} is the capital of {country}."""
         ...
 
     assert is_capital("Dublin", "Ireland") is True
@@ -43,9 +32,8 @@ def test_decorator_return_bool():
 
 @pytest.mark.openai
 def test_decorator_return_bool_str():
-    @prompt()
+    @prompt("Answer the following question: {question}.")
     def answer_question(question: str) -> bool | str:
-        """Answer the following question: {question}."""
         ...
 
     assert answer_question("What is the capital of Ireland? Name only") == "Dublin"
@@ -72,7 +60,7 @@ def test_decorator_return_pydantic_model():
         capital: str
         country: str
 
-    @prompt(template="What is the capital of {country}?")
+    @prompt("What is the capital of {country}?")
     def get_capital(country: str) -> CapitalCity:
         ...
 
@@ -85,7 +73,7 @@ def test_decorator_input_pydantic_model():
         capital: str
         country: str
 
-    @prompt(template="Is this capital-country pair correct? {pair}")
+    @prompt("Is this capital-country pair correct? {pair}")
     def check_capital(pair: CapitalCity) -> bool:
         ...
 
@@ -97,9 +85,8 @@ def test_decorator_return_function_call():
     def plus(a: int, b: int) -> int:
         return a + b
 
-    @prompt(functions=[plus])
+    @prompt("Sum the populations of {country_one} and {country_two}.", functions=[plus])
     def sum_populations(country_one: str, country_two: str) -> FunctionCall[int]:
-        """Sum the populations of {country_one} and {country_two}."""
         ...
 
     output = sum_populations("Ireland", "UK")
@@ -111,9 +98,8 @@ def test_decorator_return_function_call():
 @pytest.mark.asyncio
 @pytest.mark.openai
 async def test_async_decorator_return_str():
-    @prompt()
+    @prompt("What is the capital of {country}? Name only. No punctuation.")
     async def get_capital(country: str) -> str:
-        """What is the capital of {country}? Name only. No punctuation."""
         ...
 
     assert isinstance(get_capital, AsyncPromptFunction)
@@ -126,9 +112,8 @@ async def test_async_decorator_return_function_call():
     def plus(a: int, b: int) -> int:
         return a + b
 
-    @prompt(functions=[plus])
+    @prompt("Sum the populations of {country_one} and {country_two}.", functions=[plus])
     async def sum_populations(country_one: str, country_two: str) -> FunctionCall[int]:
-        """Sum the populations of {country_one} and {country_two}."""
         ...
 
     output = await sum_populations("Ireland", "UK")


### PR DESCRIPTION
Remove ability to use function docstring as template

- Do not use docstring as template
- Convert tests to use template arg instead of docstring
- Update README type hints examples to use template not docstring
