### PR TITLE
Raise StructuredOutputError from ValidationError to clarify error

### DIFF
--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -5,6 +5,7 @@ from inspect import getdoc
 import pytest
 from pydantic import BaseModel
 
+from magentic.chat_model.openai_chat_model import StructuredOutputError
 from magentic.function_call import FunctionCall
 from magentic.prompt_function import AsyncPromptFunction, PromptFunction, prompt
 
@@ -93,6 +94,17 @@ def test_decorator_return_function_call():
     assert isinstance(output, FunctionCall)
     func_result = output()
     assert isinstance(func_result, int)
+
+
+@pytest.mark.openai
+def test_decorator_raise_structured_output_error():
+    @prompt("How many days between {start_date} and {end_date}? Do out the math.")
+    def days_between(start_date: str, end_date: str) -> int:
+        ...
+
+    with pytest.raises(StructuredOutputError):
+        # The model will return a math expression, not an integer
+        days_between("Jan 4th 2019", "Jul 3rd 2019")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Raise a `StructuredOutputError` from a `ValidationError` when parsing model output. This provides a more helpful error message.

previously
```
ValidationError: 1 validation error for Output[int]
  Invalid JSON: expected value at line 2 column 12 [type=json_invalid, input_value='{\n  "value": (new Date(...1000 * 60 * 60 * 24)\n}', input_type=str]
    For further information visit https://errors.pydantic.dev/2.0.3/v/json_invalid
```
now
```
StructuredOutputError: Failed to parse model output '{ "value": (new Date(\'2019-07-03\') - new Date(\'2019-01-04\')) / (1000 * 60 * 60 * 24) }'. You may need to update your prompt to encourage the model to return a specific type.
```
