### PR TITLE
Add streaming for string output

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See the [examples directory](examples/) for more.
 
 ### Streaming
 
-The `StreamedStr` (and `AsyncStreamedStr`) class can be used to stream the output of the LLM. This allows you to process the text while it is being generated, rather than receiving the whole output at once. Multiple `StreamedStr` can be created at the same time to stream LLM outputs concurrently. In the below example, generating the description for a single country takes approximately the same amount of time as for multiple countries.
+The `StreamedStr` (and `AsyncStreamedStr`) class can be used to stream the output of the LLM. This allows you to process the text while it is being generated, rather than receiving the whole output at once. Multiple `StreamedStr` can be created at the same time to stream LLM outputs concurrently. In the below example, generating the description for multiple countries takes (approximately) the same amount of time as for a single country.
 
 ```python
 from magentic import prompt, StreamedStr

--- a/README.md
+++ b/README.md
@@ -128,6 +128,31 @@ LLM-powered functions created using `@prompt` and `@prompt_chain` can be supplie
 
 See the [examples directory](examples/) for more.
 
+### Streaming
+
+The `StreamedStr` (and `AsyncStreamedStr`) class can be used to stream the output of the LLM. This allows you to process the text while it is being generated, rather than receiving the whole output at once. Multiple `StreamedStr` can be created at the same time to stream LLM outputs concurrently. In the below example, generating the description for a single country takes approximately the same amount of time as for multiple countries.
+
+```python
+from magentic import prompt, StreamedStr
+
+
+@prompt("Tell me about {country}")
+def describe_country(country: str) -> StreamedStr:
+    ...
+
+
+# Print the chunks while they are being received
+for chunk in describe_country("Brazil"):
+    print(chunk, end="")
+# 'Brazil, officially known as the Federative Republic of Brazil, is ...'
+
+
+# Generate text concurrently by creating the streams before consuming them
+streamed_strs = [describe_country(c) for c in ["Australia", "Brazil", "Chile"]]
+[str(s) for s in streamed_strs]
+# ["Australia is a country ...", "Brazil, officially known as ...", "Chile, officially known as ..."]
+```
+
 ### Additional Features
 
 - The `@prompt` decorator can also be used with `async` function definitions, which enables making concurrent queries to the LLM.
@@ -136,7 +161,7 @@ See the [examples directory](examples/) for more.
 
 ## Type Checking
 
-Many type checkers will raise warnings or errors for functions with the `prompt` decorator due to the function having no body or return value. There are several ways to deal with these.
+Many type checkers will raise warnings or errors for functions with the `@prompt` decorator due to the function having no body or return value. There are several ways to deal with these.
 
 1. Disable the check globally for the type checker. For example in mypy by disabling error code `empty-body`.
    ```toml

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See the [examples directory](examples/) for more.
 
 ### Streaming
 
-The `StreamedStr` (and `AsyncStreamedStr`) class can be used to stream the output of the LLM. This allows you to process the text while it is being generated, rather than receiving the whole output at once. Multiple `StreamedStr` can be created at the same time to stream LLM outputs concurrently. In the below example, generating the description for multiple countries takes (approximately) the same amount of time as for a single country.
+The `StreamedStr` (and `AsyncStreamedStr`) class can be used to stream the output of the LLM. This allows you to process the text while it is being generated, rather than receiving the whole output at once. Multiple `StreamedStr` can be created at the same time to stream LLM outputs concurrently. In the below example, generating the description for multiple countries takes approximately the same amount of time as for a single country.
 
 ```python
 from magentic import prompt, StreamedStr

--- a/src/magentic/__init__.py
+++ b/src/magentic/__init__.py
@@ -1,11 +1,12 @@
 from magentic.function_call import FunctionCall
 from magentic.prompt_chain import prompt_chain
 from magentic.prompt_function import prompt
-from magentic.streamed_str import StreamedStr
+from magentic.streamed_str import AsyncStreamedStr, StreamedStr
 
 __all__ = [
     "FunctionCall",
     "prompt_chain",
     "prompt",
+    "AsyncStreamedStr",
     "StreamedStr",
 ]

--- a/src/magentic/__init__.py
+++ b/src/magentic/__init__.py
@@ -1,9 +1,11 @@
 from magentic.function_call import FunctionCall
 from magentic.prompt_chain import prompt_chain
 from magentic.prompt_function import prompt
+from magentic.streamed_str import StreamedStr
 
 __all__ = [
     "FunctionCall",
     "prompt_chain",
     "prompt",
+    "StreamedStr",
 ]

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -3,7 +3,7 @@ import json
 import textwrap
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Callable, Generic, Iterable, TypeVar
+from typing import Any, Callable, Generic, Iterable, Iterator, TypeVar, cast
 
 import openai
 from pydantic import BaseModel, TypeAdapter, ValidationError, create_model
@@ -16,6 +16,7 @@ from magentic.chat_model.base import (
     UserMessage,
 )
 from magentic.function_call import FunctionCall
+from magentic.streamed_str import StreamedStr
 from magentic.typing import is_origin_subclass, name_type
 
 
@@ -249,36 +250,47 @@ class OpenaiChatModel:
         function_schemas = [FunctionCallFunctionSchema(f) for f in functions or []] + [
             function_schema_for_type(type_)
             for type_ in output_types
-            if not issubclass(type_, str)
+            if not issubclass(type_, (str, StreamedStr))
         ]
 
-        includes_str_output_type = any(issubclass(cls, str) for cls in output_types)
+        str_in_output_types = any(issubclass(cls, str) for cls in output_types)
+        streamed_str_in_output_types = any(
+            issubclass(cls, StreamedStr) for cls in output_types
+        )
+        allow_string_output = str_in_output_types or streamed_str_in_output_types
 
         # `openai.ChatCompletion.create` doesn't accept `None`
         # so only pass function args if there are functions
         function_args: dict[str, Any] = {}
         if function_schemas:
             function_args["functions"] = [schema.dict() for schema in function_schemas]
-        if len(function_schemas) == 1 and not includes_str_output_type:
+        if len(function_schemas) == 1 and not allow_string_output:
             # Force the model to call the function
             function_args["function_call"] = {"name": function_schemas[0].name}
 
-        response: dict[str, Any] = openai.ChatCompletion.create(  # type: ignore[no-untyped-call]
+        response: Iterator[dict[str, Any]] = openai.ChatCompletion.create(  # type: ignore[no-untyped-call]
             model=self._model,
             messages=[message_to_openai_message(m) for m in messages],
             temperature=self._temperature,
             **function_args,
+            stream=True,
         )
-        response_message = response["choices"][0]["message"]
 
-        if response_message.get("function_call"):
+        first_chunk = next(response)
+        first_chunk_delta = first_chunk["choices"][0]["delta"]
+
+        if first_chunk_delta.get("function_call"):
             function_schema_by_name = {
                 function_schema.name: function_schema
                 for function_schema in function_schemas
             }
-            function_name = response_message["function_call"]["name"]
+            function_name = first_chunk_delta["function_call"]["name"]
             function_schema = function_schema_by_name[function_name]
-            function_call_args = response_message["function_call"]["arguments"]
+            function_call_args = "".join(
+                chunk["choices"][0]["delta"]["function_call"]["arguments"]
+                for chunk in response
+                if chunk["choices"][0]["delta"]
+            )
             try:
                 message = function_schema.parse_args_to_message(function_call_args)
             except ValidationError as e:
@@ -290,13 +302,19 @@ class OpenaiChatModel:
                 ) from e
             return message
 
-        if not includes_str_output_type:
+        if not allow_string_output:
             raise ValueError(
                 "String was returned by model but not expected. You may need to update"
                 " your prompt to encourage the model to return a specific type."
             )
-
-        return AssistantMessage(response_message["content"])
+        streamed_str = StreamedStr(
+            chunk["choices"][0]["delta"]["content"]
+            for chunk in response
+            if chunk["choices"][0]["delta"]
+        )
+        if streamed_str_in_output_types:
+            return cast(AssistantMessage[R], AssistantMessage(streamed_str))
+        return cast(AssistantMessage[R], AssistantMessage(str(streamed_str)))
 
     # TODO: Deduplicate this and `complete`
     async def acomplete(

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -3,7 +3,16 @@ import json
 import textwrap
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Callable, Generic, Iterable, Iterator, TypeVar, cast
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Generic,
+    Iterable,
+    Iterator,
+    TypeVar,
+    cast,
+)
 
 import openai
 from pydantic import BaseModel, TypeAdapter, ValidationError, create_model
@@ -16,7 +25,7 @@ from magentic.chat_model.base import (
     UserMessage,
 )
 from magentic.function_call import FunctionCall
-from magentic.streamed_str import StreamedStr
+from magentic.streamed_str import AsyncStreamedStr, StreamedStr
 from magentic.typing import is_origin_subclass, name_type
 
 
@@ -330,36 +339,49 @@ class OpenaiChatModel:
         function_schemas = [FunctionCallFunctionSchema(f) for f in functions or []] + [
             function_schema_for_type(type_)
             for type_ in output_types
-            if not issubclass(type_, str)
+            if not issubclass(type_, (str, AsyncStreamedStr))
         ]
 
-        includes_str_output_type = any(issubclass(cls, str) for cls in output_types)
+        str_in_output_types = any(issubclass(cls, str) for cls in output_types)
+        async_streamed_str_in_output_types = any(
+            issubclass(cls, AsyncStreamedStr) for cls in output_types
+        )
+        allow_string_output = str_in_output_types or async_streamed_str_in_output_types
 
         # `openai.ChatCompletion.acreate` doesn't accept `None`
         # so only pass function args if there are functions
         function_args: dict[str, Any] = {}
         if function_schemas:
             function_args["functions"] = [schema.dict() for schema in function_schemas]
-        if len(function_schemas) == 1 and not includes_str_output_type:
+        if len(function_schemas) == 1 and not allow_string_output:
             # Force the model to call the function
             function_args["function_call"] = {"name": function_schemas[0].name}
 
-        response: dict[str, Any] = await openai.ChatCompletion.acreate(  # type: ignore[no-untyped-call]
+        response: AsyncIterator[dict[str, Any]] = await openai.ChatCompletion.acreate(  # type: ignore[no-untyped-call]
             model=self._model,
             messages=[message_to_openai_message(m) for m in messages],
             temperature=self._temperature,
             **function_args,
+            stream=True,
         )
-        response_message = response["choices"][0]["message"]
 
-        if response_message.get("function_call"):
+        first_chunk = await anext(response)
+        first_chunk_delta = first_chunk["choices"][0]["delta"]
+
+        if first_chunk_delta.get("function_call"):
             function_schema_by_name = {
                 function_schema.name: function_schema
                 for function_schema in function_schemas
             }
-            function_name = response_message["function_call"]["name"]
+            function_name = first_chunk_delta["function_call"]["name"]
             function_schema = function_schema_by_name[function_name]
-            function_call_args = response_message["function_call"]["arguments"]
+            function_call_args = "".join(
+                [
+                    chunk["choices"][0]["delta"]["function_call"]["arguments"]
+                    async for chunk in response
+                    if chunk["choices"][0]["delta"]
+                ]
+            )
             try:
                 message = function_schema.parse_args_to_message(function_call_args)
             except ValidationError as e:
@@ -371,10 +393,18 @@ class OpenaiChatModel:
                 ) from e
             return message
 
-        if not includes_str_output_type:
+        if not allow_string_output:
             raise ValueError(
                 "String was returned by model but not expected. You may need to update"
                 " your prompt to encourage the model to return a specific type."
             )
-
-        return AssistantMessage(response_message["content"])
+        async_streamed_str = AsyncStreamedStr(
+            chunk["choices"][0]["delta"]["content"]
+            async for chunk in response
+            if chunk["choices"][0]["delta"]
+        )
+        if async_streamed_str_in_output_types:
+            return cast(AssistantMessage[R], AssistantMessage(async_streamed_str))
+        return cast(
+            AssistantMessage[R], AssistantMessage(await async_streamed_str.to_string())
+        )

--- a/src/magentic/streamed_str.py
+++ b/src/magentic/streamed_str.py
@@ -1,0 +1,18 @@
+from typing import Iterator
+
+
+class StreamedStr:
+    """A string that is generated in chunks."""
+
+    def __init__(self, generator: Iterator[str]):
+        self._generator = generator
+        self._cached_chunks: list[str] = []
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self._cached_chunks
+        for chunk in self._generator:
+            self._cached_chunks.append(chunk)
+            yield chunk
+
+    def __str__(self) -> str:
+        return "".join(self)

--- a/src/magentic/streamed_str.py
+++ b/src/magentic/streamed_str.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import AsyncIterator, Iterator
 
 
 class StreamedStr:
@@ -16,3 +16,28 @@ class StreamedStr:
 
     def __str__(self) -> str:
         return "".join(self)
+
+    def to_string(self) -> str:
+        """Convert the streamed string to a string."""
+        return str(self)
+
+
+class AsyncStreamedStr:
+    """A string that is generated in chunks."""
+
+    def __init__(self, generator: AsyncIterator[str]):
+        self._generator = generator
+        self._cached_chunks: list[str] = []
+
+    async def __aiter__(self) -> AsyncIterator[str]:
+        # Cannot use `yield from` inside an async function
+        # https://peps.python.org/pep-0525/#asynchronous-yield-from
+        for chunk in self._cached_chunks:
+            yield chunk
+        async for chunk in self._generator:
+            self._cached_chunks.append(chunk)
+            yield chunk
+
+    async def to_string(self) -> str:
+        """Convert the streamed string to a string."""
+        return "".join([item async for item in self])

--- a/src/magentic/streamed_str.py
+++ b/src/magentic/streamed_str.py
@@ -23,7 +23,7 @@ class StreamedStr:
 
 
 class AsyncStreamedStr:
-    """A string that is generated in chunks."""
+    """Async version of `StreamedStr`."""
 
     def __init__(self, generator: AsyncIterator[str]):
         self._generator = generator

--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from magentic.chat_model.openai_chat_model import StructuredOutputError
 from magentic.function_call import FunctionCall
 from magentic.prompt_function import AsyncPromptFunction, PromptFunction, prompt
+from magentic.streamed_str import AsyncStreamedStr, StreamedStr
 
 
 @pytest.mark.openai
@@ -97,6 +98,16 @@ def test_decorator_return_function_call():
 
 
 @pytest.mark.openai
+def test_decorator_return_streamed_str():
+    @prompt("What is the capital of {country}?")
+    def get_capital(country: str) -> StreamedStr:
+        ...
+
+    output = get_capital("Ireland")
+    assert isinstance(output, StreamedStr)
+
+
+@pytest.mark.openai
 def test_decorator_raise_structured_output_error():
     @prompt("How many days between {start_date} and {end_date}? Do out the math.")
     def days_between(start_date: str, end_date: str) -> int:
@@ -116,6 +127,17 @@ async def test_async_decorator_return_str():
 
     assert isinstance(get_capital, AsyncPromptFunction)
     assert await get_capital("Ireland") == "Dublin"
+
+
+@pytest.mark.asyncio
+@pytest.mark.openai
+async def test_async_decorator_return_async_streamed_str():
+    @prompt("What is the capital of {country}?")
+    async def get_capital(country: str) -> AsyncStreamedStr:
+        ...
+
+    output = await get_capital("Ireland")
+    assert isinstance(output, AsyncStreamedStr)
 
 
 @pytest.mark.asyncio

--- a/tests/test_streamed_str.py
+++ b/tests/test_streamed_str.py
@@ -1,6 +1,8 @@
-from typing import Iterator
+from typing import AsyncIterator, Iterator
 
-from magentic import StreamedStr
+import pytest
+
+from magentic import AsyncStreamedStr, StreamedStr
 
 
 def test_streamed_str_iter():
@@ -18,3 +20,24 @@ def test_streamed_str_str():
 
     streamed_str = StreamedStr(generator())
     assert str(streamed_str) == "Hello World"
+
+
+@pytest.mark.asyncio
+async def test_async_streamed_str_iter():
+    async def generator() -> AsyncIterator[str]:
+        for chunk in ["Hello", " World"]:
+            yield chunk
+
+    async_streamed_str = AsyncStreamedStr(generator())
+    assert [chunk async for chunk in async_streamed_str] == ["Hello", " World"]
+    assert [chunk async for chunk in async_streamed_str] == ["Hello", " World"]
+
+
+@pytest.mark.asyncio
+async def test_async_streamed_str_to_string():
+    async def generator() -> AsyncIterator[str]:
+        for chunk in ["Hello", " World"]:
+            yield chunk
+
+    async_streamed_str = AsyncStreamedStr(generator())
+    assert await async_streamed_str.to_string() == "Hello World"

--- a/tests/test_streamed_str.py
+++ b/tests/test_streamed_str.py
@@ -1,0 +1,20 @@
+from typing import Iterator
+
+from magentic import StreamedStr
+
+
+def test_streamed_str_iter():
+    def generator() -> Iterator[str]:
+        yield from ["Hello", " World"]
+
+    streamed_str = StreamedStr(generator())
+    assert list(streamed_str) == ["Hello", " World"]
+    assert list(streamed_str) == ["Hello", " World"]
+
+
+def test_streamed_str_str():
+    def generator() -> Iterator[str]:
+        yield from ["Hello", " World"]
+
+    streamed_str = StreamedStr(generator())
+    assert str(streamed_str) == "Hello World"


### PR DESCRIPTION
Add support for streaming string output. Now all responses from the openai api are streamed internally but converted to regular strings and objects unless a `StreamedStr` or `AsyncStreamedStr` was specifically requested.

Commits
- Add `StreamedStr` class
- Enable using `StreamedStr` with `.complete` method
- Add `AsyncStreamedStr`
- Enable using `AsyncStreamedStr` with `.acomplete` method
- Add Streaming section to README

---

> ### Streaming
>
> The `StreamedStr` (and `AsyncStreamedStr`) class can be used to stream the output of the LLM. This allows you to process the text while it is being generated, rather than receiving the whole output at once. Multiple `StreamedStr` can be created at the same time to stream LLM outputs concurrently. In the below example, generating the description for multiple countries takes approximately the same amount of time as for a single country.
>
> ```python
> from magentic import prompt, StreamedStr
>
>
> @prompt("Tell me about {country}")
> def describe_country(country: str) -> StreamedStr:
>     ...
>
>
> # Print the chunks while they are being received
> for chunk in describe_country("Brazil"):
>     print(chunk, end="")
> # 'Brazil, officially known as the Federative Republic of Brazil, is ...'
>
>
> # Generate text concurrently by creating the streams before consuming them
> streamed_strs = [describe_country(c) for c in ["Australia", "Brazil", "Chile"]]
> [str(s) for s in streamed_strs]
> # ["Australia is a country ...", "Brazil, officially known as ...", "Chile, officially known as ..."]
> ```