### PR TITLE
Enable more linting rules with Ruff. Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/adamchainz/blacken-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,15 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.278
+    rev: v0.0.289
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.15.0"
+    rev: "1.16.0"
     hooks:
       - id: blacken-docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ ignore = [
   "COM",  # flake8-commas
    "FA",  # flake8-future-annotations
   "INP",  # flake8-no-pep420
-  "T20",  # flake8-print
    "PT",  # flake8-pytest-style
   "SLF",  # flake8-self
   "ARG",  # flake8-unused-arguments
@@ -70,3 +69,8 @@ ignore = [
 
 [tool.ruff.isort]
 known-first-party = ["magentic"]
+
+[tool.ruff.per-file-ignores]
+"examples/*" = [
+  "T20",  # flake8-print
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ ignore = [
   "FIX",  # flake8-fixme
    "PL",  # Pylint
   "TRY",  # tryceratops
-  "RUF",  # Ruff-specific rules
 ]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,15 @@ ignore = [
   "COM",  # flake8-commas
    "FA",  # flake8-future-annotations
   "INP",  # flake8-no-pep420
-   "PT",  # flake8-pytest-style
   "SLF",  # flake8-self
   "ARG",  # flake8-unused-arguments
    "TD",  # flake8-todos
   "FIX",  # flake8-fixme
    "PL",  # Pylint
 ]
+
+[tool.ruff.flake8-pytest-style]
+mark-parentheses = false
 
 [tool.ruff.isort]
 known-first-party = ["magentic"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ ignore = [
    "TD",  # flake8-todos
   "FIX",  # flake8-fixme
    "PL",  # Pylint
-  "TRY",  # tryceratops
 ]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ ignore = [
   "ARG",  # flake8-unused-arguments
    "TD",  # flake8-todos
   "FIX",  # flake8-fixme
-  "PGH",  # pygrep-hooks
    "PL",  # Pylint
   "TRY",  # tryceratops
   "RUF",  # Ruff-specific rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ ignore = [
     "S",  # flake8-bandit
     "A",  # flake8-builtins
   "COM",  # flake8-commas
-   "EM",  # flake8-errmsg
    "FA",  # flake8-future-annotations
   "INP",  # flake8-no-pep420
   "T20",  # flake8-print

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ ignore = [
   "C90",  # mccabe
     "D",  # pydocstyle
   "ANN",  # flake8-annotations
-    "S",  # flake8-bandit
     "A",  # flake8-builtins
   "COM",  # flake8-commas
    "FA",  # flake8-future-annotations
@@ -75,4 +74,7 @@ known-first-party = ["magentic"]
 [tool.ruff.per-file-ignores]
 "examples/*" = [
   "T20",  # flake8-print
+]
+"tests/*" = [
+    "S",  # flake8-bandit
 ]

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -504,17 +504,19 @@ class OpenaiChatModel:
                     if chunk.choices[0].delta.function_call
                 )
             except ValidationError as e:
-                raise StructuredOutputError(
+                msg = (
                     "Failed to parse model output. You may need to update your prompt"
                     " to encourage the model to return a specific type."
-                ) from e
+                )
+                raise StructuredOutputError(msg) from e
             return message
 
         if not allow_string_output:
-            raise ValueError(
+            msg = (
                 "String was returned by model but not expected. You may need to update"
                 " your prompt to encourage the model to return a specific type."
             )
+            raise ValueError(msg)
         streamed_str = StreamedStr(
             chunk.choices[0].delta.content
             for chunk in response
@@ -577,17 +579,19 @@ class OpenaiChatModel:
                     if chunk.choices[0].delta.function_call
                 )
             except ValidationError as e:
-                raise StructuredOutputError(
+                msg = (
                     "Failed to parse model output. You may need to update your prompt"
                     " to encourage the model to return a specific type."
-                ) from e
+                )
+                raise StructuredOutputError(msg) from e
             return message
 
         if not allow_string_output:
-            raise ValueError(
+            msg = (
                 "String was returned by model but not expected. You may need to update"
                 " your prompt to encourage the model to return a specific type."
             )
+            raise ValueError(msg)
         async_streamed_str = AsyncStreamedStr(
             chunk.choices[0].delta.content
             async for chunk in response

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -306,7 +306,9 @@ class OpenaiChatCompletionFunctionCall(BaseModel):
 
     def get_name_or_raise(self) -> str:
         """Return the name, raising an error if it doesn't exist."""
-        assert self.name is not None
+        if self.name is None:
+            msg = "OpenAI function call name is None"
+            raise ValueError(msg)
         return self.name
 
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -147,7 +147,7 @@ class AsyncIterableFunctionSchema(
         self._item_type_adapter = TypeAdapter(get_args(output_type)[0])
         # Convert to list so pydantic can handle for schema generation
         # But keep the type hint using AsyncIterableT for type checking
-        self._model: type[Output[AsyncIterableT]] = Output[list[get_args(output_type)[0]]]  # type: ignore
+        self._model: type[Output[AsyncIterableT]] = Output[list[get_args(output_type)[0]]]  # type: ignore[index,misc]
 
     @property
     def name(self) -> str:

--- a/src/magentic/typing.py
+++ b/src/magentic/typing.py
@@ -14,7 +14,7 @@ from typing import (
 def is_union_type(type_: type) -> bool:
     """Return True if the type is a union type."""
     type_ = get_origin(type_) or type_
-    return type_ is Union or type_ is types.UnionType  # noqa: E721
+    return type_ is Union or type_ is types.UnionType
 
 
 TypeT = TypeVar("TypeT", bound=type)

--- a/src/magentic/typing.py
+++ b/src/magentic/typing.py
@@ -57,7 +57,7 @@ def name_type(type_: type) -> str:
         return f"dict_of_{name_type(key_type)}_to_{name_type(value_type)}"
 
     if name := getattr(type_, "__name__", None):
-        assert isinstance(name, str)
+        assert isinstance(name, str)  # noqa: S101
 
         if len(args) == 1:
             return f"{name.lower()}_of_{name_type(args[0])}"

--- a/src/magentic/typing.py
+++ b/src/magentic/typing.py
@@ -1,9 +1,8 @@
 import inspect
 import types
+from collections.abc import Mapping, Sequence
 from typing import (
     Any,
-    Mapping,
-    Sequence,
     TypeGuard,
     TypeVar,
     Union,
@@ -65,4 +64,5 @@ def name_type(type_: type) -> str:
 
         return name.lower()
 
-    raise ValueError(f"Unable to name type {type_}")
+    msg = f"Unable to name type {type_}"
+    raise ValueError(msg)

--- a/tests/test_function_call.py
+++ b/tests/test_function_call.py
@@ -14,7 +14,7 @@ def plus_default_value(a: int, b: int = 3) -> int:
 
 
 @pytest.mark.parametrize(
-    ["left", "right", "equal"],
+    ("left", "right", "equal"),
     [
         (FunctionCall(plus, a=1, b=2), FunctionCall(plus, a=1, b=2), True),
         (FunctionCall(plus, a=1, b=2), FunctionCall(plus, a=1, b=33), False),
@@ -40,7 +40,7 @@ def test_function_call_eq(left, right, equal):
 
 
 @pytest.mark.parametrize(
-    ["function_call", "arguments"],
+    ("function_call", "arguments"),
     [
         (FunctionCall(plus, a=1, b=2), {"a": 1, "b": 2}),
         (FunctionCall(plus, 1, 2), {"a": 1, "b": 2}),

--- a/tests/test_openai_chat_model.py
+++ b/tests/test_openai_chat_model.py
@@ -22,7 +22,7 @@ from magentic.typing import is_origin_subclass
 
 
 @pytest.mark.parametrize(
-    ["type_", "json_schema"],
+    ("type_", "json_schema"),
     [
         (
             str,
@@ -151,7 +151,7 @@ any_function_schema_args_test_cases = [
 
 
 @pytest.mark.parametrize(
-    ["type_", "args_str", "expected_args"], any_function_schema_args_test_cases
+    ("type_", "args_str", "expected_args"), any_function_schema_args_test_cases
 )
 def test_any_function_schema_parse_args(type_, args_str, expected_args):
     parsed_args = AnyFunctionSchema(type_).parse_args(args_str)
@@ -159,7 +159,7 @@ def test_any_function_schema_parse_args(type_, args_str, expected_args):
 
 
 @pytest.mark.parametrize(
-    ["type_", "args_str", "expected_args"], any_function_schema_args_test_cases
+    ("type_", "args_str", "expected_args"), any_function_schema_args_test_cases
 )
 @pytest.mark.asyncio
 async def test_any_function_schema_aparse_args(type_, args_str, expected_args):
@@ -168,7 +168,7 @@ async def test_any_function_schema_aparse_args(type_, args_str, expected_args):
 
 
 @pytest.mark.parametrize(
-    ["type_", "expected_args_str", "args"], any_function_schema_args_test_cases
+    ("type_", "expected_args_str", "args"), any_function_schema_args_test_cases
 )
 def test_any_function_schema_serialize_args(type_, expected_args_str, args):
     serialized_args = AnyFunctionSchema(type_).serialize_args(args)
@@ -176,7 +176,7 @@ def test_any_function_schema_serialize_args(type_, expected_args_str, args):
 
 
 @pytest.mark.parametrize(
-    ["type_", "json_schema"],
+    ("type_", "json_schema"),
     [
         (
             list[str],
@@ -244,7 +244,7 @@ iterable_function_schema_args_test_cases = [
 
 
 @pytest.mark.parametrize(
-    ["type_", "args_str", "expected_args"], iterable_function_schema_args_test_cases
+    ("type_", "args_str", "expected_args"), iterable_function_schema_args_test_cases
 )
 def test_iterable_function_schema_parse_args(type_, args_str, expected_args):
     parsed_args = IterableFunctionSchema(type_).parse_args(args_str)
@@ -253,7 +253,7 @@ def test_iterable_function_schema_parse_args(type_, args_str, expected_args):
 
 
 @pytest.mark.parametrize(
-    ["type_", "expected_args_str", "args"], iterable_function_schema_args_test_cases
+    ("type_", "expected_args_str", "args"), iterable_function_schema_args_test_cases
 )
 def test_iterable_function_schema_serialize_args(type_, expected_args_str, args):
     serialized_args = IterableFunctionSchema(type_).serialize_args(args)
@@ -261,7 +261,7 @@ def test_iterable_function_schema_serialize_args(type_, expected_args_str, args)
 
 
 @pytest.mark.parametrize(
-    ["type_", "json_schema"],
+    ("type_", "json_schema"),
     [
         (
             typing.AsyncIterable[str],
@@ -311,7 +311,7 @@ async_iterable_function_schema_args_test_cases = [
 
 
 @pytest.mark.parametrize(
-    ["type_", "args_str", "expected_args"],
+    ("type_", "args_str", "expected_args"),
     async_iterable_function_schema_args_test_cases,
 )
 @pytest.mark.asyncio
@@ -326,7 +326,7 @@ async def test_async_iterable_function_schema_aparse_args(
 
 
 @pytest.mark.parametrize(
-    ["type_", "expected_args_str", "args"],
+    ("type_", "expected_args_str", "args"),
     async_iterable_function_schema_args_test_cases,
 )
 def test_async_iterable_function_schema_serialize_args(type_, expected_args_str, args):
@@ -340,7 +340,7 @@ class User(BaseModel):
 
 
 @pytest.mark.parametrize(
-    ["type_", "json_schema"],
+    ("type_", "json_schema"),
     [
         (
             dict,
@@ -417,7 +417,7 @@ dict_function_schema_args_test_cases = [
 
 
 @pytest.mark.parametrize(
-    ["type_", "args_str", "expected_args"], dict_function_schema_args_test_cases
+    ("type_", "args_str", "expected_args"), dict_function_schema_args_test_cases
 )
 def test_dict_function_schema_parse_args(type_, args_str, expected_args):
     parsed_args = DictFunctionSchema(type_).parse_args(args_str)
@@ -426,7 +426,7 @@ def test_dict_function_schema_parse_args(type_, args_str, expected_args):
 
 
 @pytest.mark.parametrize(
-    ["type_", "expected_args_str", "args"], dict_function_schema_args_test_cases
+    ("type_", "expected_args_str", "args"), dict_function_schema_args_test_cases
 )
 def test_dict_function_schema_serialize_args(type_, expected_args_str, args):
     serialized_args = DictFunctionSchema(type_).serialize_args(args)
@@ -478,7 +478,7 @@ def plus_with_annotated(
 
 
 @pytest.mark.parametrize(
-    ["function", "json_schema"],
+    ("function", "json_schema"),
     [
         (
             plus,
@@ -589,7 +589,7 @@ function_call_function_schema_args_test_cases = [
 
 
 @pytest.mark.parametrize(
-    ["function", "args_str", "expected_args"],
+    ("function", "args_str", "expected_args"),
     function_call_function_schema_args_test_cases,
 )
 def test_function_call_function_schema_parse_args(function, args_str, expected_args):
@@ -598,7 +598,7 @@ def test_function_call_function_schema_parse_args(function, args_str, expected_a
 
 
 @pytest.mark.parametrize(
-    ["function", "expected_args_str", "args"],
+    ("function", "expected_args_str", "args"),
     function_call_function_schema_args_test_cases,
 )
 def test_function_call_function_schema_serialize_args(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -27,12 +27,12 @@ iter_streamed_json_array_test_cases = [
 ]
 
 
-@pytest.mark.parametrize(["input", "expected"], iter_streamed_json_array_test_cases)
+@pytest.mark.parametrize(("input", "expected"), iter_streamed_json_array_test_cases)
 def test_iter_streamed_json_array(input, expected):
     assert list(iter_streamed_json_array(iter(input))) == expected
 
 
-@pytest.mark.parametrize(["input", "expected"], iter_streamed_json_array_test_cases)
+@pytest.mark.parametrize(("input", "expected"), iter_streamed_json_array_test_cases)
 @pytest.mark.asyncio
 async def test_aiter_streamed_json_array(input, expected):
     assert [x async for x in aiter_streamed_json_array(async_iter(input))] == expected

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -13,7 +13,7 @@ from magentic.typing import (
 
 
 @pytest.mark.parametrize(
-    ["type_", "expected_types"],
+    ("type_", "expected_types"),
     [
         (str, ["str"]),
         (int, ["int"]),
@@ -25,7 +25,7 @@ def test_split_union_type(type_, expected_types):
 
 
 @pytest.mark.parametrize(
-    ["type_", "expected_result"],
+    ("type_", "expected_result"),
     [
         (str, False),
         (list[str], False),
@@ -37,7 +37,7 @@ def test_is_origin_abstract(type_, expected_result):
 
 
 @pytest.mark.parametrize(
-    ["type_", "cls_or_tuple", "expected_result"],
+    ("type_", "cls_or_tuple", "expected_result"),
     [
         (str, str, True),
         (str, int, False),
@@ -52,7 +52,7 @@ def test_is_origin_subclass(type_, cls_or_tuple, expected_result):
 
 
 @pytest.mark.parametrize(
-    ["type_", "expected_name"],
+    ("type_", "expected_name"),
     [
         (str, "str"),
         (int, "int"),


### PR DESCRIPTION
- Enable flake8-errmsg
- Enable pygrep-hooks
- Enable Ruff-specific rules. Update pre-commit
- Enable tryceratops
- Ignore flake8-print just for examples/ dir
- Enable flake8-pytest-style
- Ignore flake8-bandit only for tests
