### PR TITLE
Enable async prompt_chain. Remove FunctionCallMessage

### DIFF
--- a/src/magentic/chat.py
+++ b/src/magentic/chat.py
@@ -1,7 +1,14 @@
+import inspect
 from typing import Any, Callable, Iterable, ParamSpec, TypeVar
 
-from magentic.chat_model.base import AssistantMessage, Message, UserMessage
+from magentic.chat_model.base import (
+    AssistantMessage,
+    FunctionResultMessage,
+    Message,
+    UserMessage,
+)
 from magentic.chat_model.openai_chat_model import OpenaiChatModel
+from magentic.function_call import FunctionCall
 from magentic.prompt_function import BasePromptFunction
 
 P = ParamSpec("P")
@@ -65,6 +72,10 @@ class Chat:
         """Add a user message to the chat."""
         return self.add_message(UserMessage(content=content))
 
+    def add_assistant_message(self: Self, content: Any) -> Self:
+        """Add an assistant message to the chat."""
+        return self.add_message(AssistantMessage(content=content))
+
     def submit(self: Self) -> Self:
         """Request an LLM message to be added to the chat."""
         output_message: AssistantMessage[Any] = self._model.complete(
@@ -82,3 +93,29 @@ class Chat:
             output_types=self._output_types,
         )
         return self.add_message(output_message)
+
+    def exec_function_call(self: Self) -> Self:
+        """If the last message is a function call, execute it and add the result."""
+        last_message = self._messages[-1]
+        if not isinstance(last_message.content, FunctionCall):
+            msg = "Last message is not a function call."
+            raise TypeError(msg)
+
+        return self.add_message(
+            FunctionResultMessage.from_function_call(last_message.content)
+        )
+
+    async def aexec_function_call(self: Self) -> Self:
+        """Async version of `exec_function_call`."""
+        last_message = self._messages[-1]
+        if not isinstance(last_message.content, FunctionCall):
+            msg = "Last message is not a function call."
+            raise TypeError(msg)
+
+        output = last_message.content()
+        if inspect.isawaitable(output):
+            output = await output
+
+        return self.add_message(
+            FunctionResultMessage(content=output, function_call=last_message.content)
+        )

--- a/src/magentic/chat.py
+++ b/src/magentic/chat.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Iterable, ParamSpec, TypeVar
 
 from magentic.chat_model.base import AssistantMessage, Message, UserMessage
 from magentic.chat_model.openai_chat_model import OpenaiChatModel
-from magentic.prompt_function import PromptFunction
+from magentic.prompt_function import BasePromptFunction
 
 P = ParamSpec("P")
 Self = TypeVar("Self", bound="Chat")
@@ -24,7 +24,7 @@ class Chat:
     @classmethod
     def from_prompt(
         cls: type[Self],
-        prompt: PromptFunction[P, Any],
+        prompt: BasePromptFunction[P, Any],
         *args: P.args,
         **kwargs: P.kwargs
     ) -> Self:
@@ -54,6 +54,15 @@ class Chat:
     def submit(self: Self) -> Self:
         """Request an LLM message."""
         output_message: AssistantMessage[Any] = self._model.complete(
+            messages=self._messages,
+            functions=self._functions,
+            output_types=self._output_types,
+        )
+        return self.add_message(output_message)
+
+    async def asubmit(self: Self) -> Self:
+        """Async version of `submit`."""
+        output_message: AssistantMessage[Any] = await self._model.acomplete(
             messages=self._messages,
             functions=self._functions,
             output_types=self._output_types,

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Generic, TypeVar
+from typing import Awaitable, Generic, TypeVar, overload
 
 from magentic.function_call import FunctionCall
 
@@ -34,6 +34,14 @@ class AssistantMessage(Message[T], Generic[T]):
 
 class FunctionResultMessage(Message[T], Generic[T]):
     """A message containing the result of a function call."""
+
+    @overload
+    def __init__(self, content: T, function_call: FunctionCall[T]):
+        ...
+
+    @overload
+    def __init__(self, content: T, function_call: FunctionCall[Awaitable[T]]):
+        ...
 
     def __init__(
         self, content: T, function_call: FunctionCall[T] | FunctionCall[Awaitable[T]]

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -52,6 +52,7 @@ class FunctionResultMessage(Message[T], Generic[T]):
         )
 
 
+# TODO: Delete this class?
 class FunctionCallMessage(AssistantMessage[FunctionCall[T]], Generic[T]):
     def get_result(self) -> FunctionResultMessage[T]:
         return FunctionResultMessage.from_function_call(self.content)

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -55,12 +55,3 @@ class FunctionResultMessage(Message[T], Generic[T]):
             content=function_call(),
             function_call=function_call,
         )
-
-
-# TODO: Delete this class?
-class FunctionCallMessage(AssistantMessage[FunctionCall[T]], Generic[T]):
-    """A message containing a function call."""
-
-    def get_result(self) -> FunctionResultMessage[T]:
-        """Call the function and return a message containing the result."""
-        return FunctionResultMessage.from_function_call(self.content)

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar
+from typing import Awaitable, Generic, TypeVar
 
 from magentic.function_call import FunctionCall
 
@@ -35,7 +35,9 @@ class AssistantMessage(Message[T], Generic[T]):
 class FunctionResultMessage(Message[T], Generic[T]):
     """A message containing the result of a function call."""
 
-    def __init__(self, content: T, function_call: FunctionCall[T]):
+    def __init__(
+        self, content: T, function_call: FunctionCall[T] | FunctionCall[Awaitable[T]]
+    ):
         super().__init__(content)
         self._function_call = function_call
 
@@ -43,7 +45,7 @@ class FunctionResultMessage(Message[T], Generic[T]):
         return f"{self.__class__.__name__}({self.content!r}, {self._function_call!r})"
 
     @property
-    def function_call(self) -> FunctionCall[T]:
+    def function_call(self) -> FunctionCall[T] | FunctionCall[Awaitable[T]]:
         return self._function_call
 
     @classmethod
@@ -53,5 +55,15 @@ class FunctionResultMessage(Message[T], Generic[T]):
         """Create a message containing the result of a function call."""
         return cls(
             content=function_call(),
+            function_call=function_call,
+        )
+
+    @classmethod
+    async def afrom_function_call(
+        cls, function_call: FunctionCall[Awaitable[T]]
+    ) -> "FunctionResultMessage[T]":
+        """Async version of `from_function_call`."""
+        return cls(
+            content=await function_call(),
             function_call=function_call,
         )

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel, TypeAdapter, ValidationError, create_model
 
 from magentic.chat_model.base import (
     AssistantMessage,
-    FunctionCallMessage,
     FunctionResultMessage,
     Message,
     UserMessage,
@@ -274,17 +273,6 @@ class FunctionCallFunctionSchema(BaseFunctionSchema[FunctionCall[T]], Generic[T]
         )
         return FunctionCall(self._func, **args)
 
-    async def aparse_args(self, arguments: AsyncIterable[str]) -> FunctionCall[T]:
-        return self.parse_args([arg async for arg in arguments])
-
-    def parse_args_to_message(self, arguments: Iterable[str]) -> FunctionCallMessage[T]:
-        return FunctionCallMessage(self.parse_args(arguments))
-
-    async def aparse_args_to_message(
-        self, arguments: AsyncIterable[str]
-    ) -> FunctionCallMessage[T]:
-        return FunctionCallMessage(await self.aparse_args(arguments))
-
     def serialize_args(self, value: FunctionCall[T]) -> str:
         return json.dumps(value.arguments)
 
@@ -475,7 +463,11 @@ class OpenaiChatModel:
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
-    ) -> FunctionCallMessage[FuncR] | AssistantMessage[R]:
+    ) -> (
+        AssistantMessage[FunctionCall[FuncR]]
+        | AssistantMessage[R]
+        | AssistantMessage[str]
+    ):
         """Request an LLM message."""
         if output_types is None:
             output_types = [str]
@@ -550,7 +542,11 @@ class OpenaiChatModel:
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
-    ) -> FunctionCallMessage[FuncR] | AssistantMessage[R]:
+    ) -> (
+        AssistantMessage[FunctionCall[FuncR]]
+        | AssistantMessage[R]
+        | AssistantMessage[str]
+    ):
         """Async version of `complete`."""
         if output_types is None:
             output_types = [str]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -35,3 +35,15 @@ def test_chat_submit():
     assert chat1.messages == [UserMessage(content="Hello")]
     assert chat2.messages[0] == UserMessage(content="Hello")
     assert isinstance(chat2.messages[1], AssistantMessage)
+
+
+@pytest.mark.asyncio
+@pytest.mark.openai
+async def test_chat_asubmit():
+    chat1 = Chat(
+        messages=[UserMessage(content="Hello")],
+    )
+    chat2 = await chat1.asubmit()
+    assert chat1.messages == [UserMessage(content="Hello")]
+    assert chat2.messages[0] == UserMessage(content="Hello")
+    assert isinstance(chat2.messages[1], AssistantMessage)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -70,6 +70,18 @@ def test_exec_function_call():
     assert chat.messages[2] == FunctionResultMessage(3, FunctionCall(plus, 1, 2))
 
 
+def test_exec_function_call_raises():
+    def plus(a: int, b: int) -> int:
+        return a + b
+
+    chat = Chat(
+        messages=[UserMessage(content="What is 1 plus 2?")],
+        functions=[plus],
+    )
+    with pytest.raises(TypeError):
+        chat = chat.exec_function_call()
+
+
 @pytest.mark.asyncio
 async def test_aexec_function_call_async_function():
     async def aplus(a: int, b: int) -> int:
@@ -102,3 +114,16 @@ async def test_aexec_function_call_not_async_function():
     chat = await chat.aexec_function_call()
     assert len(chat.messages) == 3
     assert chat.messages[2] == FunctionResultMessage(3, FunctionCall(plus, 1, 2))
+
+
+@pytest.mark.asyncio
+async def test_aexec_function_call_raises():
+    async def aplus(a: int, b: int) -> int:
+        return a + b
+
+    chat = Chat(
+        messages=[UserMessage(content="What is 1 plus 2?")],
+        functions=[aplus],
+    )
+    with pytest.raises(TypeError):
+        chat = await chat.aexec_function_call()

--- a/tests/test_prompt_chain.py
+++ b/tests/test_prompt_chain.py
@@ -23,3 +23,26 @@ def test_prompt_chain():
 
     output = describe_weather("Boston")
     assert isinstance(output, str)
+
+
+@pytest.mark.asyncio
+@pytest.mark.openai
+async def test_async_prompt_chain():
+    async def get_current_weather(location, unit="fahrenheit"):
+        """Get the current weather in a given location"""
+        return {
+            "location": location,
+            "temperature": "72",
+            "unit": unit,
+            "forecast": ["sunny", "windy"],
+        }
+
+    @prompt_chain(
+        template="What's the weather like in {city}?",
+        functions=[get_current_weather],
+    )
+    async def describe_weather(city: str) -> str:
+        ...
+
+    output = await describe_weather("Boston")
+    assert isinstance(output, str)


### PR DESCRIPTION
- Enable async functions to be used with `@prompt_chain`
- Add `Chat.exec_function_call`, `Chat.aexec_function_call`, `Chat.asubmit` methods
- Delete `FunctionCallMessage` and remove usage from openai_chat_model

---

```python
from magentic import prompt_chain


async def get_current_weather(location, unit="fahrenheit"):
    """Get the current weather in a given location"""
    return {
        "location": location,
        "temperature": "72",
        "unit": unit,
        "forecast": ["sunny", "windy"],
    }


@prompt_chain(
    template="What's the weather like in {city}?",
    functions=[get_current_weather],
)
async def describe_weather(city: str) -> str:
    ...


output = await describe_weather("Boston")
```