### PR TITLE
Make AsyncIterableFunctionSchema.serialize_args raise NotImplementedError

### DIFF
--- a/src/magentic/chat_model/function_schemas.py
+++ b/src/magentic/chat_model/function_schemas.py
@@ -162,7 +162,7 @@ class AsyncIterableFunctionSchema(
         raise NotImplementedError
 
     def serialize_args(self, value: AsyncIterableT) -> str:
-        return self._model(value=value).model_dump_json()  # type: ignore[arg-type]
+        raise NotImplementedError
 
 
 class DictFunctionSchema(BaseFunctionSchema[T], Generic[T]):

--- a/tests/test_function_schemas.py
+++ b/tests/test_function_schemas.py
@@ -363,8 +363,8 @@ async def test_async_iterable_function_schema_aparse_args(
     async_iterable_function_schema_args_test_cases,
 )
 def test_async_iterable_function_schema_serialize_args(type_, expected_args_str, args):
-    serialized_args = AsyncIterableFunctionSchema(type_).serialize_args(args)
-    assert json.loads(serialized_args) == json.loads(expected_args_str)
+    with pytest.raises(NotImplementedError):
+        AsyncIterableFunctionSchema(type_).serialize_args(async_iter(args))
 
 
 class User(BaseModel):


### PR DESCRIPTION
Make `AsyncIterableFunctionSchema.serialize_args` raise `NotImplementedError`. It is a sync function so it cannot async-iterate the value passed as input.