### PR TITLE
Add chatprompt decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ See the [examples directory](examples/) for more.
 
 ### Chat Prompting
 
-The `@chatprompt` decorator works just like `@prompt` but allows you to pass chat messages rather than a single text prompt. This can be used for few-shot prompting where you provide example responses to guide the model's output.
+The `@chatprompt` decorator works just like `@prompt` but allows you to pass chat messages as a template rather than a single text prompt. This can be used to provide a system message or for few-shot prompting where you provide example responses to guide the model's output. Format fields denoted by curly braces `{example}` will be filled in all messages - use the `escape_braces` function to prevent a string being used as a template.
 
 ```python
 from magentic import chatprompt, AssistantMessage, SystemMessage, UserMessage
+from magentic.chatprompt import escape_braces
 
 from pydantic import BaseModel
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,29 @@ LLM-powered functions created using `@prompt` and `@prompt_chain` can be supplie
 
 See the [examples directory](examples/) for more.
 
+### Chat Prompting
+
+The `@chatprompt` decorator works just like `@prompt` but allows you to pass chat messages rather than a single text prompt. This can be used for few-shot prompting where you provide example responses to guide the output.
+
+```python
+from magentic import prompt, AssistantMessage, SystemMessage, UserMessage
+
+
+@chatprompt(
+    SystemMessage("Only use uppercase letters."),
+    UserMessage("What is your favorite quote from Harry Potter?"),
+    AssistantMessage(
+        ("It does not do to dwell on dreams and forget to live.", "Albus Dumbledore")
+    ),
+    UserMessage("What is your favorite quote from {movie}?"),
+)
+def get_movie_quote(movie: str) -> tuple[str, str]:
+    ...
+
+
+get_movie_quote("Iron Man 3")
+```
+
 ### Streaming
 
 The `StreamedStr` (and `AsyncStreamedStr`) class can be used to stream the output of the LLM. This allows you to process the text while it is being generated, rather than receiving the whole output at once.

--- a/README.md
+++ b/README.md
@@ -130,25 +130,36 @@ See the [examples directory](examples/) for more.
 
 ### Chat Prompting
 
-The `@chatprompt` decorator works just like `@prompt` but allows you to pass chat messages rather than a single text prompt. This can be used for few-shot prompting where you provide example responses to guide the output.
+The `@chatprompt` decorator works just like `@prompt` but allows you to pass chat messages rather than a single text prompt. This can be used for few-shot prompting where you provide example responses to guide the model's output.
 
 ```python
-from magentic import prompt, AssistantMessage, SystemMessage, UserMessage
+from magentic import chatprompt, AssistantMessage, SystemMessage, UserMessage
+
+from pydantic import BaseModel
+
+
+class Quote(BaseModel):
+    quote: str
+    character: str
 
 
 @chatprompt(
-    SystemMessage("Only use uppercase letters."),
+    SystemMessage("You are a movie buff."),
     UserMessage("What is your favorite quote from Harry Potter?"),
     AssistantMessage(
-        ("It does not do to dwell on dreams and forget to live.", "Albus Dumbledore")
+        Quote(
+            quote="It does not do to dwell on dreams and forget to live.",
+            character="Albus Dumbledore",
+        )
     ),
     UserMessage("What is your favorite quote from {movie}?"),
 )
-def get_movie_quote(movie: str) -> tuple[str, str]:
+def get_movie_quote(movie: str) -> Quote:
     ...
 
 
-get_movie_quote("Iron Man 3")
+get_movie_quote("Iron Man")
+# Quote(quote='I am Iron Man.', character='Tony Stark')
 ```
 
 ### Streaming

--- a/src/magentic/__init__.py
+++ b/src/magentic/__init__.py
@@ -1,9 +1,19 @@
+from magentic.chat_model.message import (
+    AssistantMessage,
+    SystemMessage,
+    UserMessage,
+)
+from magentic.chatprompt import chatprompt
 from magentic.function_call import FunctionCall
 from magentic.prompt_chain import prompt_chain
 from magentic.prompt_function import prompt
 from magentic.streaming import AsyncStreamedStr, StreamedStr
 
 __all__ = [
+    "AssistantMessage",
+    "SystemMessage",
+    "UserMessage",
+    "chatprompt",
     "FunctionCall",
     "prompt_chain",
     "prompt",

--- a/src/magentic/__init__.py
+++ b/src/magentic/__init__.py
@@ -1,5 +1,6 @@
 from magentic.chat_model.message import (
     AssistantMessage,
+    FunctionResultMessage,
     SystemMessage,
     UserMessage,
 )
@@ -11,6 +12,7 @@ from magentic.streaming import AsyncStreamedStr, StreamedStr
 
 __all__ = [
     "AssistantMessage",
+    "FunctionResultMessage",
     "SystemMessage",
     "UserMessage",
     "chatprompt",

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -24,6 +24,10 @@ class Message(Generic[T]):
         return self._content
 
 
+class SystemMessage(Message[str]):
+    """A message to the LLM to guide the whole chat."""
+
+
 class UserMessage(Message[str]):
     """A message sent by a user to an LLM chat model."""
 

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Awaitable, Generic, TypeVar, overload
 
 from magentic.function_call import FunctionCall
@@ -5,7 +6,7 @@ from magentic.function_call import FunctionCall
 T = TypeVar("T")
 
 
-class Message(Generic[T]):
+class Message(Generic[T], ABC):
     """A message sent to or from an LLM chat model."""
 
     def __init__(self, content: T):
@@ -23,17 +24,30 @@ class Message(Generic[T]):
     def content(self) -> T:
         return self._content
 
+    @abstractmethod
+    def with_content(self, content: T) -> "Message[T]":
+        raise NotImplementedError
+
 
 class SystemMessage(Message[str]):
     """A message to the LLM to guide the whole chat."""
+
+    def with_content(self, content: str) -> "SystemMessage":
+        return SystemMessage(content)
 
 
 class UserMessage(Message[str]):
     """A message sent by a user to an LLM chat model."""
 
+    def with_content(self, content: str) -> "UserMessage":
+        return UserMessage(content)
+
 
 class AssistantMessage(Message[T], Generic[T]):
     """A message received from an LLM chat model."""
+
+    def with_content(self, content: T) -> "AssistantMessage[T]":
+        return AssistantMessage(content)
 
 
 class FunctionResultMessage(Message[T], Generic[T]):
@@ -59,6 +73,9 @@ class FunctionResultMessage(Message[T], Generic[T]):
     @property
     def function_call(self) -> FunctionCall[T] | FunctionCall[Awaitable[T]]:
         return self._function_call
+
+    def with_content(self, content: T) -> "FunctionResultMessage[T]":
+        return FunctionResultMessage(content, self._function_call)
 
     @classmethod
     def from_function_call(

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -14,6 +14,7 @@ from magentic.chat_model.message import (
     AssistantMessage,
     FunctionResultMessage,
     Message,
+    SystemMessage,
     UserMessage,
 )
 from magentic.function_call import FunctionCall
@@ -81,6 +82,11 @@ def message_to_openai_message(
     message: Message[Any],
 ) -> OpenaiChatCompletionChoiceMessage:
     """Convert a Message to an OpenAI message."""
+    if isinstance(message, SystemMessage):
+        return OpenaiChatCompletionChoiceMessage(
+            role=OpenaiMessageRole.SYSTEM, content=message.content
+        )
+
     if isinstance(message, UserMessage):
         return OpenaiChatCompletionChoiceMessage(
             role=OpenaiMessageRole.USER, content=message.content

--- a/src/magentic/chatprompt.py
+++ b/src/magentic/chatprompt.py
@@ -163,7 +163,7 @@ def chatprompt(
     >>>     UserMessage("What is your favorite quote from {movie}?"),
     >>> )
     >>> def get_movie_quote(movie: str) -> Quote:
-    >>> ...
+    >>>     ...
     >>>
     >>>
     >>> get_movie_quote("Iron Man")

--- a/src/magentic/chatprompt.py
+++ b/src/magentic/chatprompt.py
@@ -70,10 +70,9 @@ class BaseChatPromptFunction(Generic[P, R]):
 
         messages = []
         for message_template in self._messages:
-            if isinstance(content := message_template.content, str):
-                messages.append(
-                    type(message_template)(content.format(**bound_args.arguments))
-                )
+            if isinstance(message_template.content, str):
+                content = message_template.content.format(**bound_args.arguments)
+                messages.append(message_template.with_content(content))
             else:
                 messages.append(message_template)
 

--- a/src/magentic/chatprompt.py
+++ b/src/magentic/chatprompt.py
@@ -1,0 +1,190 @@
+import inspect
+from functools import update_wrapper
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Generic,
+    ParamSpec,
+    Protocol,
+    Sequence,
+    TypeVar,
+    cast,
+    overload,
+)
+
+from magentic.chat_model.message import Message
+from magentic.chat_model.openai_chat_model import OpenaiChatModel
+from magentic.function_call import FunctionCall
+from magentic.typing import is_origin_subclass, split_union_type
+
+P = ParamSpec("P")
+# TODO: Make `R` type Union of all possible return types except FunctionCall ?
+# Then `R | FunctionCall[FuncR]` will separate FunctionCall from other return types.
+# Can then use `FuncR` to make typechecker check `functions` argument to `chatprompt`
+# `Not` type would solve this - https://github.com/python/typing/issues/801
+R = TypeVar("R")
+
+
+class BaseChatPromptFunction(Generic[P, R]):
+    """Base class for an LLM chat prompt template that is directly callable to query the LLM."""
+
+    def __init__(
+        self,
+        messages: Sequence[Message[Any]],
+        parameters: Sequence[inspect.Parameter],
+        return_type: type[R],
+        functions: list[Callable[..., Any]] | None = None,
+        model: OpenaiChatModel | None = None,
+    ):
+        self._signature = inspect.Signature(
+            parameters=parameters,
+            return_annotation=return_type,
+        )
+        self._messages = messages
+        self._functions = functions or []
+        self._model = model or OpenaiChatModel()
+
+        self._return_types = [
+            type_
+            for type_ in split_union_type(return_type)
+            if not is_origin_subclass(type_, FunctionCall)
+        ]
+
+    @property
+    def functions(self) -> list[Callable[..., Any]]:
+        return self._functions.copy()
+
+    @property
+    def model(self) -> OpenaiChatModel:
+        return self._model
+
+    @property
+    def return_types(self) -> list[type[R]]:
+        return self._return_types.copy()
+
+    def format(self, *args: P.args, **kwargs: P.kwargs) -> list[Message[Any]]:
+        """Format the message templates with the given arguments."""
+        bound_args = self._signature.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+
+        messages = []
+        for message_template in self._messages:
+            if isinstance(content := message_template.content, str):
+                messages.append(
+                    type(message_template)(content.format(**bound_args.arguments))
+                )
+            else:
+                messages.append(message_template)
+
+        return messages
+
+
+class ChatPromptFunction(BaseChatPromptFunction[P, R], Generic[P, R]):
+    """An LLM chat prompt template that is directly callable to query the LLM."""
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Query the LLM with the formatted chat prompt template."""
+        message = self._model.complete(
+            messages=self.format(*args, **kwargs),
+            functions=self._functions,
+            output_types=self._return_types,
+        )
+        return cast(R, message.content)
+
+
+class AsyncChatPromptFunction(BaseChatPromptFunction[P, R], Generic[P, R]):
+    """Async version of `ChatPromptFunction`."""
+
+    async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Asynchronously query the LLM with the formatted chat prompt template."""
+        message = await self._model.acomplete(
+            messages=self.format(*args, **kwargs),
+            functions=self._functions,
+            output_types=self._return_types,
+        )
+        return cast(R, message.content)
+
+
+class ChatPromptDecorator(Protocol):
+    """Protocol for a decorator that returns a `ChatPromptFunction`.
+
+    This allows finer-grain type annotation of the `chatprompt` function
+    See https://github.com/microsoft/pyright/issues/5014#issuecomment-1523778421
+    """
+
+    @overload
+    def __call__(self, func: Callable[P, Awaitable[R]]) -> AsyncChatPromptFunction[P, R]:  # type: ignore[misc]
+        ...
+
+    @overload
+    def __call__(self, func: Callable[P, R]) -> ChatPromptFunction[P, R]:
+        ...
+
+
+def chatprompt(
+    *messages: Message[Any],
+    functions: list[Callable[..., Any]] | None = None,
+    model: OpenaiChatModel | None = None,
+) -> ChatPromptDecorator:
+    """Convert a function into an LLM chat prompt template.
+
+    The `@chatprompt` decorator allows you to define a prompt template for a chat-based Large Language Model (LLM).
+
+    Examples
+    --------
+    >>> from magentic import chatprompt, AssistantMessage, SystemMessage, UserMessage
+    >>>
+    >>> from pydantic import BaseModel
+    >>>
+    >>>
+    >>> class Quote(BaseModel):
+    >>>     quote: str
+    >>>     character: str
+    >>>
+    >>>
+    >>> @chatprompt(
+    >>>     SystemMessage("You are a movie buff."),
+    >>>     UserMessage("What is your favorite quote from Harry Potter?"),
+    >>>     AssistantMessage(
+    >>>         Quote(
+    >>>             quote="It does not do to dwell on dreams and forget to live.",
+    >>>             character="Albus Dumbledore",
+    >>>         )
+    >>>     ),
+    >>>     UserMessage("What is your favorite quote from {movie}?"),
+    >>> )
+    >>> def get_movie_quote(movie: str) -> Quote:
+    >>> ...
+    >>>
+    >>>
+    >>> get_movie_quote("Iron Man")
+    Quote(quote='I am Iron Man.', character='Tony Stark')
+    """
+
+    def decorator(
+        func: Callable[P, Awaitable[R]] | Callable[P, R]
+    ) -> AsyncChatPromptFunction[P, R] | ChatPromptFunction[P, R]:
+        func_signature = inspect.signature(func)
+
+        if inspect.iscoroutinefunction(func):
+            async_prompt_function = AsyncChatPromptFunction[P, R](
+                messages=messages,
+                parameters=list(func_signature.parameters.values()),
+                return_type=func_signature.return_annotation,
+                functions=functions,
+                model=model,
+            )
+            async_prompt_function = update_wrapper(async_prompt_function, func)
+            return cast(AsyncChatPromptFunction[P, R], async_prompt_function)  # type: ignore[redundant-cast]
+
+        prompt_function = ChatPromptFunction[P, R](
+            messages=messages,
+            parameters=list(func_signature.parameters.values()),
+            return_type=func_signature.return_annotation,
+            functions=functions,
+            model=model,
+        )
+        return cast(ChatPromptFunction[P, R], update_wrapper(prompt_function, func))  # type: ignore[redundant-cast]
+
+    return cast(ChatPromptDecorator, decorator)

--- a/src/magentic/chatprompt.py
+++ b/src/magentic/chatprompt.py
@@ -26,6 +26,15 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+def escape_braces(text: str) -> str:
+    """Escape curly braces in a string.
+
+    This allows curly braces to be used in a string template without being interpreted
+    as format specifiers.
+    """
+    return text.replace("{", "{{").replace("}", "}}")
+
+
 class BaseChatPromptFunction(Generic[P, R]):
     """Base class for an LLM chat prompt template that is directly callable to query the LLM."""
 

--- a/src/magentic/prompt_function.py
+++ b/src/magentic/prompt_function.py
@@ -75,12 +75,8 @@ class PromptFunction(BasePromptFunction[P, R], Generic[P, R]):
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         """Query the LLM with the formatted prompt template."""
-        bound_args = self._signature.bind(*args, **kwargs)
-        bound_args.apply_defaults()
         message = self._model.complete(
-            messages=[
-                UserMessage(content=self._template.format(**bound_args.arguments))
-            ],
+            messages=[UserMessage(content=self.format(*args, **kwargs))],
             functions=self._functions,
             output_types=self._return_types,
         )
@@ -92,12 +88,8 @@ class AsyncPromptFunction(BasePromptFunction[P, R], Generic[P, R]):
 
     async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         """Asynchronously query the LLM with the formatted prompt template."""
-        bound_args = self._signature.bind(*args, **kwargs)
-        bound_args.apply_defaults()
         message = await self._model.acomplete(
-            messages=[
-                UserMessage(content=self._template.format(**bound_args.arguments))
-            ],
+            messages=[UserMessage(content=self.format(*args, **kwargs))],
             functions=self._functions,
             output_types=self._return_types,
         )

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -4,6 +4,7 @@ from inspect import getdoc
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from pydantic import BaseModel
 
 from magentic.chat_model.message import AssistantMessage, SystemMessage, UserMessage
 from magentic.chatprompt import AsyncChatPromptFunction, ChatPromptFunction, chatprompt
@@ -85,3 +86,27 @@ async def test_async_chatprompt_decorator_docstring():
 
     assert isinstance(func, AsyncChatPromptFunction)
     assert getdoc(func) == "This is the docstring."
+
+
+@pytest.mark.openai
+def test_chatprompt_readme_example():
+    class Quote(BaseModel):
+        quote: str
+        character: str
+
+    @chatprompt(
+        SystemMessage("You are a movie buff."),
+        UserMessage("What is your favorite quote from Harry Potter?"),
+        AssistantMessage(
+            Quote(
+                quote="It does not do to dwell on dreams and forget to live.",
+                character="Albus Dumbledore",
+            )
+        ),
+        UserMessage("What is your favorite quote from {movie}?"),
+    )
+    def get_movie_quote(movie: str) -> Quote:
+        ...
+
+    movie_quote = get_movie_quote("Iron Man")
+    assert isinstance(movie_quote, Quote)

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -1,0 +1,87 @@
+"""Tests for @chatprompt decorator."""
+
+from inspect import getdoc
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from magentic.chat_model.message import AssistantMessage, SystemMessage, UserMessage
+from magentic.chatprompt import AsyncChatPromptFunction, ChatPromptFunction, chatprompt
+
+
+def test_chatpromptfunction_format():
+    @chatprompt(
+        SystemMessage("This is a system message with {one}."),
+        UserMessage("This is a {two} user message."),
+        AssistantMessage("This {three} is an assistant message."),
+        AssistantMessage([1, 2, 3]),
+    )
+    def func(one: int, two: bool, three: str) -> str:  # noqa: FBT001
+        ...
+
+    assert func.format(one=1, two=True, three="three") == [
+        SystemMessage("This is a system message with 1."),
+        UserMessage("This is a True user message."),
+        AssistantMessage("This three is an assistant message."),
+        AssistantMessage([1, 2, 3]),
+    ]
+
+
+def test_chatpromptfunction_call():
+    mock_model = Mock()
+    mock_model.complete.return_value = AssistantMessage(content="Hello!")
+
+    @chatprompt(
+        UserMessage("Hello {name}."),
+        model=mock_model,
+    )
+    def say_hello(name: str) -> str | bool:
+        ...
+
+    assert say_hello("World") == "Hello!"
+    assert mock_model.complete.call_count == 1
+    assert mock_model.complete.call_args.kwargs["messages"] == [
+        UserMessage("Hello World.")
+    ]
+    assert mock_model.complete.call_args.kwargs["output_types"] == [str, bool]
+
+
+def test_chatprompt_decorator_docstring():
+    @chatprompt(UserMessage("This is a user message."))
+    def func(one: int) -> str:
+        """This is the docstring."""
+        ...
+
+    assert isinstance(func, ChatPromptFunction)
+    assert getdoc(func) == "This is the docstring."
+
+
+@pytest.mark.asyncio
+async def test_asyncchatpromptfunction_call():
+    mock_model = AsyncMock()
+    mock_model.acomplete.return_value = AssistantMessage(content="Hello!")
+
+    @chatprompt(
+        UserMessage("Hello {name}."),
+        model=mock_model,
+    )
+    async def say_hello(name: str) -> str | bool:
+        ...
+
+    assert await say_hello("World") == "Hello!"
+    assert mock_model.acomplete.call_count == 1
+    assert mock_model.acomplete.call_args.kwargs["messages"] == [
+        UserMessage("Hello World.")
+    ]
+    assert mock_model.acomplete.call_args.kwargs["output_types"] == [str, bool]
+
+
+@pytest.mark.asyncio
+async def test_async_chatprompt_decorator_docstring():
+    @chatprompt(UserMessage("This is a user message."))
+    async def func(one: int) -> str:
+        """This is the docstring."""
+        ...
+
+    assert isinstance(func, AsyncChatPromptFunction)
+    assert getdoc(func) == "This is the docstring."

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -10,22 +10,33 @@ from magentic.chat_model.message import AssistantMessage, SystemMessage, UserMes
 from magentic.chatprompt import AsyncChatPromptFunction, ChatPromptFunction, chatprompt
 
 
-def test_chatpromptfunction_format():
-    @chatprompt(
-        SystemMessage("This is a system message with {one}."),
-        UserMessage("This is a {two} user message."),
-        AssistantMessage("This {three} is an assistant message."),
-        AssistantMessage([1, 2, 3]),
-    )
-    def func(one: int, two: bool, three: str) -> str:  # noqa: FBT001
+@pytest.mark.parametrize(
+    ("message_templates", "expected_messages"),
+    [
+        (
+            [AssistantMessage([1, 2, 3])],
+            [AssistantMessage([1, 2, 3])],
+        ),
+        (
+            [SystemMessage("System message with {param}.")],
+            [SystemMessage("System message with arg.")],
+        ),
+        (
+            [UserMessage("User message with {param}.")],
+            [UserMessage("User message with arg.")],
+        ),
+        (
+            [AssistantMessage("Assistant message with {param}.")],
+            [AssistantMessage("Assistant message with arg.")],
+        ),
+    ],
+)
+def test_chatpromptfunction_format(message_templates, expected_messages):
+    @chatprompt(*message_templates)
+    def func(param: str) -> str:
         ...
 
-    assert func.format(one=1, two=True, three="three") == [
-        SystemMessage("This is a system message with 1."),
-        UserMessage("This is a True user message."),
-        AssistantMessage("This three is an assistant message."),
-        AssistantMessage([1, 2, 3]),
-    ]
+    assert func.format(param="arg") == expected_messages
 
 
 def test_chatpromptfunction_call():

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -12,7 +12,21 @@ from magentic.chat_model.message import (
     SystemMessage,
     UserMessage,
 )
-from magentic.chatprompt import AsyncChatPromptFunction, ChatPromptFunction, chatprompt
+from magentic.chatprompt import (
+    AsyncChatPromptFunction,
+    ChatPromptFunction,
+    chatprompt,
+    escape_braces,
+)
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", "test", "{test}", "{{test}}", "{{test"],
+)
+def test_escape_braces(text):
+    """Test that `escape_braces` makes `str.format` recover the original string."""
+    assert escape_braces(text).format() == text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from pydantic import BaseModel
 
-from magentic.chat_model.message import AssistantMessage, SystemMessage, UserMessage
+from magentic.chat_model.message import (
+    AssistantMessage,
+    FunctionResultMessage,
+    SystemMessage,
+    UserMessage,
+)
 from magentic.chatprompt import AsyncChatPromptFunction, ChatPromptFunction, chatprompt
 
 
@@ -28,6 +33,18 @@ from magentic.chatprompt import AsyncChatPromptFunction, ChatPromptFunction, cha
         (
             [AssistantMessage("Assistant message with {param}.")],
             [AssistantMessage("Assistant message with arg.")],
+        ),
+        (
+            [
+                FunctionResultMessage(
+                    "Function result message with {param}", function_call=Mock()
+                )
+            ],
+            [
+                FunctionResultMessage(
+                    "Function result message with arg", function_call=Mock()
+                )
+            ],
         ),
     ],
 )


### PR DESCRIPTION
Add a new decorator `@chatprompt` which allows defining a prompt for a chat model consisting of a set of templated chat messages.

Resolves https://github.com/jackmpcollins/magentic/issues/31
Closes https://github.com/jackmpcollins/magentic/pull/27

---

### Chat Prompting

The `@chatprompt` decorator works just like `@prompt` but allows you to pass chat messages as a template rather than a single text prompt. This can be used to provide a system message or for few-shot prompting where you provide example responses to guide the model's output. Format fields denoted by curly braces `{example}` will be filled in all messages - use the `escape_braces` function to prevent a string being used as a template.

```python
from magentic import chatprompt, AssistantMessage, SystemMessage, UserMessage
from magentic.chatprompt import escape_braces

from pydantic import BaseModel


class Quote(BaseModel):
    quote: str
    character: str


@chatprompt(
    SystemMessage("You are a movie buff."),
    UserMessage("What is your favorite quote from Harry Potter?"),
    AssistantMessage(
        Quote(
            quote="It does not do to dwell on dreams and forget to live.",
            character="Albus Dumbledore",
        )
    ),
    UserMessage("What is your favorite quote from {movie}?"),
)
def get_movie_quote(movie: str) -> Quote:
    ...


get_movie_quote("Iron Man")
# Quote(quote='I am Iron Man.', character='Tony Stark')
```