### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate Llama2 CodeLlama (100+LLMs) - using LiteLLM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ repository = "https://github.com/jackmpcollins/magentic"
 [tool.poetry.dependencies]
 python = ">=3.10"
 openai = ">=0.27"
+litellm = ">=0.1.817"
 pydantic = ">=2.0.0"
 pydantic-settings = ">=2.0.0"
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Any, Literal, TypeVar, cast
 
 import openai
+import litellm
 from pydantic import BaseModel, ValidationError
 
 from magentic.chat_model.function_schema import (
@@ -131,8 +132,8 @@ def openai_chatcompletion_create(
     functions: list[dict[str, Any]] | None = None,
     function_call: Literal["auto", "none"] | dict[str, Any] | None = None,
 ) -> Iterator[OpenaiChatCompletionChunk]:
-    """Type-annotated version of `openai.ChatCompletion.create`."""
-    # `openai.ChatCompletion.create` doesn't accept `None`
+    """Type-annotated version of `litellm.completion`."""
+    # `litellm.completion` doesn't accept `None`
     # so only pass function args if there are functions
     kwargs: dict[str, Any] = {}
     if functions:
@@ -140,7 +141,7 @@ def openai_chatcompletion_create(
     if function_call:
         kwargs["function_call"] = function_call
 
-    response: Iterator[dict[str, Any]] = openai.ChatCompletion.create(  # type: ignore[no-untyped-call]
+    response: Iterator[dict[str, Any]] = litellm.completion(  # type: ignore[no-untyped-call]
         model=model,
         messages=[m.model_dump(mode="json", exclude_unset=True) for m in messages],
         temperature=temperature,
@@ -157,8 +158,8 @@ async def openai_chatcompletion_acreate(
     functions: list[dict[str, Any]] | None = None,
     function_call: Literal["auto", "none"] | dict[str, Any] | None = None,
 ) -> AsyncIterator[OpenaiChatCompletionChunk]:
-    """Type-annotated version of `openai.ChatCompletion.acreate`."""
-    # `openai.ChatCompletion.create` doesn't accept `None`
+    """Type-annotated version of `litellm.acompletion`."""
+    # `litellm.completion` doesn't accept `None`
     # so only pass function args if there are functions
     kwargs: dict[str, Any] = {}
     if functions:
@@ -166,7 +167,7 @@ async def openai_chatcompletion_acreate(
     if function_call:
         kwargs["function_call"] = function_call
 
-    response: AsyncIterator[dict[str, Any]] = await openai.ChatCompletion.acreate(  # type: ignore[no-untyped-call]
+    response: AsyncIterator[dict[str, Any]] = await litellm.acompletion(  # type: ignore[no-untyped-call]
         model=model,
         messages=[m.model_dump(mode="json", exclude_unset=True) for m in messages],
         temperature=temperature,


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```