### PR TITLE
add optional max_calls argument to prompt_chain

### DIFF
--- a/src/magentic/prompt_chain.py
+++ b/src/magentic/prompt_chain.py
@@ -50,8 +50,8 @@ def prompt_chain(
                 while isinstance(chat.messages[-1].content, FunctionCall):
                     if max_calls is not None and num_calls >= max_calls:
                         msg = (
-                            f"Function {func.__name__} reached {max_calls} function"
-                            " calls"
+                            f"Function {func.__name__} reached limit of"
+                            f" {max_calls} function calls"
                         )
                         raise MaxFunctionCallsError(msg)
                     chat = await chat.aexec_function_call()
@@ -75,7 +75,10 @@ def prompt_chain(
             num_calls = 0
             while isinstance(chat.messages[-1].content, FunctionCall):
                 if max_calls is not None and num_calls >= max_calls:
-                    msg = f"Function {func.__name__} reached {max_calls} function calls"
+                    msg = (
+                        f"Function {func.__name__} reached limit of"
+                        f" {max_calls} function calls"
+                    )
                     raise MaxFunctionCallsError(msg)
                 chat = chat.exec_function_call().submit()
                 num_calls += 1

--- a/src/magentic/prompt_chain.py
+++ b/src/magentic/prompt_chain.py
@@ -49,7 +49,8 @@ def prompt_chain(
                 calls = 0
                 while isinstance(chat.messages[-1].content, FunctionCall):
                     if max_calls is not None and calls >= max_calls:
-                        raise MaxFunctionCallsError()
+                        msg = f"Function {func.__name__} reached {max_calls} function calls"
+                        raise MaxFunctionCallsError(msg)
                     chat = await chat.aexec_function_call()
                     chat = await chat.asubmit()
                     calls += 1
@@ -71,7 +72,8 @@ def prompt_chain(
             calls = 0
             while isinstance(chat.messages[-1].content, FunctionCall):
                 if max_calls is not None and calls >= max_calls:
-                    raise MaxFunctionCallsError()
+                    msg = f"Function {func.__name__} reached {max_calls} function calls"
+                    raise MaxFunctionCallsError(msg)
                 chat = chat.exec_function_call().submit()
                 calls += 1
             return cast(R, chat.messages[-1].content)

--- a/tests/test_prompt_chain.py
+++ b/tests/test_prompt_chain.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from magentic.chat_model.message import AssistantMessage
+from magentic.function_call import FunctionCall
 from magentic.prompt_chain import MaxFunctionCallsError, prompt_chain
 
 
@@ -39,7 +40,9 @@ def test_prompt_chain_max_calls():
         }
 
     mock_model = Mock()
-    mock_model.complete.return_value = AssistantMessage(content="Weather yay!")
+    mock_model.complete.return_value = AssistantMessage(
+        content=FunctionCall(get_current_weather, "Boston")
+    )
 
     @prompt_chain(
         template="What's the weather like in {city}?",

--- a/tests/test_prompt_chain.py
+++ b/tests/test_prompt_chain.py
@@ -1,7 +1,8 @@
 import pytest
 
-from magentic.prompt_chain import prompt_chain
-
+from magentic.prompt_chain import prompt_chain, MaxFunctionCallsError
+from unittest.mock import Mock
+from magentic.chat_model.message import AssistantMessage
 
 @pytest.mark.openai
 def test_prompt_chain():
@@ -24,8 +25,6 @@ def test_prompt_chain():
     output = describe_weather("Boston")
     assert isinstance(output, str)
 
-
-@pytest.mark.openai
 def test_prompt_chain_max_calls():
     def get_current_weather(location, unit="fahrenheit"):
         """Get the current weather in a given location"""
@@ -35,16 +34,18 @@ def test_prompt_chain_max_calls():
             "unit": unit,
             "forecast": ["sunny", "windy"],
         }
-
+    mock_model = Mock()
+    mock_model.complete.return_value = AssistantMessage(content="Weather yay!") 
     @prompt_chain(
         template="What's the weather like in {city}?",
         functions=[get_current_weather],
+        model=mock_model,
         max_calls=0
     )
     def describe_weather(city: str) -> str:
         ...
 
-    with pytest.raises(PermissionError):
+    with pytest.raises(MaxFunctionCallsError):
         describe_weather("Boston")
 
 

--- a/tests/test_prompt_chain.py
+++ b/tests/test_prompt_chain.py
@@ -25,6 +25,29 @@ def test_prompt_chain():
     assert isinstance(output, str)
 
 
+@pytest.mark.openai
+def test_prompt_chain_max_calls():
+    def get_current_weather(location, unit="fahrenheit"):
+        """Get the current weather in a given location"""
+        return {
+            "location": location,
+            "temperature": "72",
+            "unit": unit,
+            "forecast": ["sunny", "windy"],
+        }
+
+    @prompt_chain(
+        template="What's the weather like in {city}?",
+        functions=[get_current_weather],
+        max_calls=0
+    )
+    def describe_weather(city: str) -> str:
+        ...
+
+    with pytest.raises(PermissionError):
+        describe_weather("Boston")
+
+
 @pytest.mark.asyncio
 @pytest.mark.openai
 async def test_async_prompt_chain():
@@ -46,3 +69,5 @@ async def test_async_prompt_chain():
 
     output = await describe_weather("Boston")
     assert isinstance(output, str)
+
+

--- a/tests/test_prompt_chain.py
+++ b/tests/test_prompt_chain.py
@@ -1,8 +1,10 @@
+from unittest.mock import Mock
+
 import pytest
 
-from magentic.prompt_chain import prompt_chain, MaxFunctionCallsError
-from unittest.mock import Mock
 from magentic.chat_model.message import AssistantMessage
+from magentic.prompt_chain import MaxFunctionCallsError, prompt_chain
+
 
 @pytest.mark.openai
 def test_prompt_chain():
@@ -25,6 +27,7 @@ def test_prompt_chain():
     output = describe_weather("Boston")
     assert isinstance(output, str)
 
+
 def test_prompt_chain_max_calls():
     def get_current_weather(location, unit="fahrenheit"):
         """Get the current weather in a given location"""
@@ -34,13 +37,15 @@ def test_prompt_chain_max_calls():
             "unit": unit,
             "forecast": ["sunny", "windy"],
         }
+
     mock_model = Mock()
-    mock_model.complete.return_value = AssistantMessage(content="Weather yay!") 
+    mock_model.complete.return_value = AssistantMessage(content="Weather yay!")
+
     @prompt_chain(
         template="What's the weather like in {city}?",
         functions=[get_current_weather],
         model=mock_model,
-        max_calls=0
+        max_calls=0,
     )
     def describe_weather(city: str) -> str:
         ...
@@ -70,5 +75,3 @@ async def test_async_prompt_chain():
 
     output = await describe_weather("Boston")
     assert isinstance(output, str)
-
-

--- a/tests/test_prompt_chain.py
+++ b/tests/test_prompt_chain.py
@@ -30,31 +30,25 @@ def test_prompt_chain():
 
 
 def test_prompt_chain_max_calls():
-    def get_current_weather(location, unit="fahrenheit"):
-        """Get the current weather in a given location"""
-        return {
-            "location": location,
-            "temperature": "72",
-            "unit": unit,
-            "forecast": ["sunny", "windy"],
-        }
-
+    mock_function = Mock()
     mock_model = Mock()
     mock_model.complete.return_value = AssistantMessage(
-        content=FunctionCall(get_current_weather, "Boston")
+        content=FunctionCall(mock_function)
     )
 
     @prompt_chain(
-        template="What's the weather like in {city}?",
-        functions=[get_current_weather],
+        template="...",
+        functions=[mock_function],
         model=mock_model,
-        max_calls=0,
+        max_calls=1,
     )
-    def describe_weather(city: str) -> str:
+    def make_function_call() -> str:
         ...
 
     with pytest.raises(MaxFunctionCallsError):
-        describe_weather("Boston")
+        make_function_call()
+    assert mock_model.complete.call_count == 2
+    assert mock_function.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I added an optional max_calls parameter to the prompt_chain decorator in order to limit api calls. By default, when it's not given unlimited calls can be made just like before. If it's given and the limit is reached, a PermissionError is raised.