### PR TITLE
Allow setting max_tokens param

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ The following environment variables can be set.
 | Environment Variable        | Description                           | Example               |
 | --------------------------- | ------------------------------------- | --------------------- |
 | MAGENTIC_OPENAI_MODEL       | OpenAI model                          | gpt-4                 |
+| MAGENTIC_OPENAI_MAX_TOKENS  | OpenAI max number of generated tokens | 1024                  |
 | MAGENTIC_OPENAI_TEMPERATURE | OpenAI temperature                    | 0.5                   |
 | OPENAI_API_BASE             | Base URL for an OpenAI-compatible API | http://localhost:8080 |
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator
 from enum import Enum
-from typing import Any, Literal, TypeVar, cast
+from typing import Any, Literal, TypeVar, cast, overload
 
 import openai
 from pydantic import BaseModel, ValidationError
@@ -216,6 +216,42 @@ class OpenaiChatModel:
             return self._temperature
         return get_settings().openai_temperature
 
+    @overload
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: None = ...,
+        output_types: None = ...,
+    ) -> AssistantMessage[str]:
+        ...
+
+    @overload
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]],
+        output_types: None = ...,
+    ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
+        ...
+
+    @overload
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: None = ...,
+        output_types: Iterable[type[R]] = ...,
+    ) -> AssistantMessage[R]:
+        ...
+
+    @overload
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]],
+        output_types: Iterable[type[R]],
+    ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
+        ...
+
     def complete(
         self,
         messages: Iterable[Message[Any]],
@@ -295,6 +331,42 @@ class OpenaiChatModel:
         if streamed_str_in_output_types:
             return cast(AssistantMessage[R], AssistantMessage(streamed_str))
         return cast(AssistantMessage[R], AssistantMessage(str(streamed_str)))
+
+    @overload
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: None = ...,
+        output_types: None = ...,
+    ) -> AssistantMessage[str]:
+        ...
+
+    @overload
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]],
+        output_types: None = ...,
+    ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
+        ...
+
+    @overload
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: None = ...,
+        output_types: Iterable[type[R]] = ...,
+    ) -> AssistantMessage[R]:
+        ...
+
+    @overload
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]],
+        output_types: Iterable[type[R]],
+    ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
+        ...
 
     async def acomplete(
         self,

--- a/src/magentic/settings.py
+++ b/src/magentic/settings.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="MAGENTIC_")
 
     openai_model: str = "gpt-3.5-turbo"
+    openai_max_tokens: int | None = None
     openai_temperature: float | None = None
 
 

--- a/tests/test_openai_chat_model.py
+++ b/tests/test_openai_chat_model.py
@@ -1,3 +1,6 @@
+import pytest
+
+from magentic.chat_model.message import AssistantMessage, UserMessage
 from magentic.chat_model.openai_chat_model import (
     OpenaiChatModel,
 )
@@ -8,6 +11,24 @@ def test_openai_chat_model_model(monkeypatch):
     assert OpenaiChatModel().model == "gpt-4"
 
 
+def test_openai_chat_model_max_tokens(monkeypatch):
+    monkeypatch.setenv("MAGENTIC_OPENAI_MAX_TOKENS", "1024")
+    assert OpenaiChatModel().max_tokens == 1024
+
+
 def test_openai_chat_model_temperature(monkeypatch):
     monkeypatch.setenv("MAGENTIC_OPENAI_TEMPERATURE", "2")
     assert OpenaiChatModel().temperature == 2
+
+
+@pytest.mark.openai
+def test_openai_chat_model_completion():
+    model = OpenaiChatModel(
+        model="gpt-3.5-turbo",
+        max_tokens=5,
+        temperature=0.5,
+    )
+    response = model.complete(messages=[UserMessage("Hello!")])
+    assert isinstance(response, AssistantMessage)
+    assert isinstance(response.content, str)
+    # TODO: test for num_tokens here


### PR DESCRIPTION
Allow setting `max_tokens` param in `OpenaiChatModel`. The default value for this can also be set using an environment variable `MAGENTIC_OPENAI_MAX_TOKENS`.

Example

```python
from magentic import prompt
from magentic.chat_model.openai_chat_model import OpenaiChatModel

@prompt("Hello, how are you?", model=OpenaiChatModel(max_tokens=3))
def test() -> str:
    ...

test()
# 'Hello! I'
```

Fixes https://github.com/jackmpcollins/magentic/issues/44

Also added type hint overloads for `OpenaiChatModel.(a)complete` to make it more correct/specific.
