### PR TITLE
Make backend configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ The following environment variables can be set.
 
 | Environment Variable        | Description                           | Example               |
 | --------------------------- | ------------------------------------- | --------------------- |
+| MAGENTIC_BACKEND            | The package to use as the LLM backend | openai                |
 | MAGENTIC_OPENAI_MODEL       | OpenAI model                          | gpt-4                 |
 | MAGENTIC_OPENAI_MAX_TOKENS  | OpenAI max number of generated tokens | 1024                  |
 | MAGENTIC_OPENAI_TEMPERATURE | OpenAI temperature                    | 0.5                   |

--- a/examples/quiz/1_quiz_async.py
+++ b/examples/quiz/1_quiz_async.py
@@ -69,7 +69,7 @@ class Question(BaseModel):
 @prompt(
     "Generate a quiz question about {topic} with difficulty {difficulty}/5.",
     # Increase temperature to try generate unique questions
-    model=OpenaiChatModel(temperature=1),
+    model=OpenaiChatModel("gpt-3.5-turbo", temperature=1),
 )
 async def generate_question(topic: str, difficulty: int) -> Question:
     ...

--- a/src/magentic/backend.py
+++ b/src/magentic/backend.py
@@ -11,6 +11,7 @@ def get_chat_model() -> OpenaiChatModel:
 
             return OpenaiChatModel(
                 model=settings.openai_model,
+                max_tokens=settings.openai_max_tokens,
                 temperature=settings.openai_temperature,
             )
         case _:

--- a/src/magentic/backend.py
+++ b/src/magentic/backend.py
@@ -1,8 +1,8 @@
-from magentic.chat_model.openai_chat_model import OpenaiChatModel
+from magentic.chat_model.base import ChatModel
 from magentic.settings import Backend, get_settings
 
 
-def get_chat_model() -> OpenaiChatModel:
+def get_chat_model() -> ChatModel:
     settings = get_settings()
 
     match (settings.backend):

--- a/src/magentic/backend.py
+++ b/src/magentic/backend.py
@@ -5,7 +5,7 @@ from magentic.settings import Backend, get_settings
 def get_chat_model() -> ChatModel:
     settings = get_settings()
 
-    match (settings.backend):
+    match settings.backend:
         case Backend.OPENAI:
             from magentic.chat_model.openai_chat_model import OpenaiChatModel
 

--- a/src/magentic/backend.py
+++ b/src/magentic/backend.py
@@ -1,0 +1,18 @@
+from magentic.chat_model.openai_chat_model import OpenaiChatModel
+from magentic.settings import Backend, get_settings
+
+
+def get_chat_model() -> OpenaiChatModel:
+    settings = get_settings()
+
+    match (settings.backend):
+        case Backend.OPENAI:
+            from magentic.chat_model.openai_chat_model import OpenaiChatModel
+
+            return OpenaiChatModel(
+                model=settings.openai_model,
+                temperature=settings.openai_temperature,
+            )
+        case _:
+            msg = f"Backend {settings.backend} does not support chat model."
+            raise NotImplementedError(msg)

--- a/src/magentic/chat.py
+++ b/src/magentic/chat.py
@@ -2,13 +2,13 @@ import inspect
 from typing import Any, Callable, Iterable, ParamSpec, TypeVar
 
 from magentic.backend import get_chat_model
+from magentic.chat_model.base import ChatModel
 from magentic.chat_model.message import (
     AssistantMessage,
     FunctionResultMessage,
     Message,
     UserMessage,
 )
-from magentic.chat_model.openai_chat_model import OpenaiChatModel
 from magentic.function_call import FunctionCall
 from magentic.prompt_function import BasePromptFunction
 
@@ -34,7 +34,7 @@ class Chat:
         messages: list[Message[Any]] | None = None,
         functions: Iterable[Callable[..., Any]] | None = None,
         output_types: Iterable[type[Any]] | None = None,
-        model: OpenaiChatModel | None = None,
+        model: ChatModel | None = None,
     ):
         self._messages = list(messages) if messages else []
         self._functions = list(functions) if functions else []
@@ -61,7 +61,7 @@ class Chat:
         return self._messages.copy()
 
     @property
-    def model(self) -> OpenaiChatModel:
+    def model(self) -> ChatModel:
         return self._model or get_chat_model()
 
     def add_message(self: Self, message: Message[Any]) -> Self:

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -1,0 +1,124 @@
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
+from typing import Any, TypeVar, overload
+
+from magentic.chat_model.message import (
+    AssistantMessage,
+    Message,
+)
+from magentic.function_call import FunctionCall
+
+R = TypeVar("R")
+FuncR = TypeVar("FuncR")
+
+
+class ChatModel(ABC):
+    """An LLM chat model."""
+
+    @overload
+    @abstractmethod
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: None = ...,
+        output_types: None = ...,
+    ) -> AssistantMessage[str]:
+        ...
+
+    @overload
+    @abstractmethod
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]],
+        output_types: None = ...,
+    ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
+        ...
+
+    @overload
+    @abstractmethod
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: None = ...,
+        output_types: Iterable[type[R]] = ...,
+    ) -> AssistantMessage[R]:
+        ...
+
+    @overload
+    @abstractmethod
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]],
+        output_types: Iterable[type[R]],
+    ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
+        ...
+
+    @abstractmethod
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]] | None = None,
+        output_types: Iterable[type[R | str]] | None = None,
+    ) -> (
+        AssistantMessage[FunctionCall[FuncR]]
+        | AssistantMessage[R]
+        | AssistantMessage[str]
+    ):
+        """Request an LLM message."""
+        ...
+
+    @overload
+    @abstractmethod
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: None = ...,
+        output_types: None = ...,
+    ) -> AssistantMessage[str]:
+        ...
+
+    @overload
+    @abstractmethod
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]],
+        output_types: None = ...,
+    ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
+        ...
+
+    @overload
+    @abstractmethod
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: None = ...,
+        output_types: Iterable[type[R]] = ...,
+    ) -> AssistantMessage[R]:
+        ...
+
+    @overload
+    @abstractmethod
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]],
+        output_types: Iterable[type[R]],
+    ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
+        ...
+
+    @abstractmethod
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., FuncR]] | None = None,
+        output_types: Iterable[type[R | str]] | None = None,
+    ) -> (
+        AssistantMessage[FunctionCall[FuncR]]
+        | AssistantMessage[R]
+        | AssistantMessage[str]
+    ):
+        """Async version of `complete`."""
+        ...

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -5,6 +5,7 @@ from typing import Any, Literal, TypeVar, cast, overload
 import openai
 from pydantic import BaseModel, ValidationError
 
+from magentic.chat_model.base import ChatModel
 from magentic.chat_model.function_schema import (
     BaseFunctionSchema,
     FunctionCallFunctionSchema,
@@ -183,7 +184,7 @@ R = TypeVar("R")
 FuncR = TypeVar("FuncR")
 
 
-class OpenaiChatModel:
+class OpenaiChatModel(ChatModel):
     """An LLM chat model that uses the `openai` python package."""
 
     def __init__(

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -18,7 +18,6 @@ from magentic.chat_model.message import (
     UserMessage,
 )
 from magentic.function_call import FunctionCall
-from magentic.settings import get_settings
 from magentic.streaming import (
     AsyncStreamedStr,
     StreamedStr,
@@ -183,21 +182,17 @@ FuncR = TypeVar("FuncR")
 class OpenaiChatModel:
     """An LLM chat model that uses the `openai` python package."""
 
-    def __init__(self, model: str | None = None, temperature: float | None = None):
+    def __init__(self, model: str, temperature: float | None = None):
         self._model = model
         self._temperature = temperature
 
     @property
     def model(self) -> str:
-        if self._model is not None:
-            return self._model
-        return get_settings().openai_model
+        return self._model
 
     @property
     def temperature(self) -> float | None:
-        if self._temperature is not None:
-            return self._temperature
-        return get_settings().openai_temperature
+        return self._temperature
 
     def complete(
         self,

--- a/src/magentic/chatprompt.py
+++ b/src/magentic/chatprompt.py
@@ -14,8 +14,8 @@ from typing import (
 )
 
 from magentic.backend import get_chat_model
+from magentic.chat_model.base import ChatModel
 from magentic.chat_model.message import Message
-from magentic.chat_model.openai_chat_model import OpenaiChatModel
 from magentic.function_call import FunctionCall
 from magentic.typing import is_origin_subclass, split_union_type
 
@@ -45,7 +45,7 @@ class BaseChatPromptFunction(Generic[P, R]):
         parameters: Sequence[inspect.Parameter],
         return_type: type[R],
         functions: list[Callable[..., Any]] | None = None,
-        model: OpenaiChatModel | None = None,
+        model: ChatModel | None = None,
     ):
         self._signature = inspect.Signature(
             parameters=parameters,
@@ -66,7 +66,7 @@ class BaseChatPromptFunction(Generic[P, R]):
         return self._functions.copy()
 
     @property
-    def model(self) -> OpenaiChatModel:
+    def model(self) -> ChatModel:
         return self._model or get_chat_model()
 
     @property
@@ -134,7 +134,7 @@ class ChatPromptDecorator(Protocol):
 def chatprompt(
     *messages: Message[Any],
     functions: list[Callable[..., Any]] | None = None,
-    model: OpenaiChatModel | None = None,
+    model: ChatModel | None = None,
 ) -> ChatPromptDecorator:
     """Convert a function into an LLM chat prompt template.
 

--- a/src/magentic/chatprompt.py
+++ b/src/magentic/chatprompt.py
@@ -13,6 +13,7 @@ from typing import (
     overload,
 )
 
+from magentic.backend import get_chat_model
 from magentic.chat_model.message import Message
 from magentic.chat_model.openai_chat_model import OpenaiChatModel
 from magentic.function_call import FunctionCall
@@ -52,7 +53,7 @@ class BaseChatPromptFunction(Generic[P, R]):
         )
         self._messages = messages
         self._functions = functions or []
-        self._model = model or OpenaiChatModel()
+        self._model = model
 
         self._return_types = [
             type_
@@ -66,7 +67,7 @@ class BaseChatPromptFunction(Generic[P, R]):
 
     @property
     def model(self) -> OpenaiChatModel:
-        return self._model
+        return self._model or get_chat_model()
 
     @property
     def return_types(self) -> list[type[R]]:
@@ -93,7 +94,7 @@ class ChatPromptFunction(BaseChatPromptFunction[P, R], Generic[P, R]):
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         """Query the LLM with the formatted chat prompt template."""
-        message = self._model.complete(
+        message = self.model.complete(
             messages=self.format(*args, **kwargs),
             functions=self._functions,
             output_types=self._return_types,
@@ -106,7 +107,7 @@ class AsyncChatPromptFunction(BaseChatPromptFunction[P, R], Generic[P, R]):
 
     async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         """Asynchronously query the LLM with the formatted chat prompt template."""
-        message = await self._model.acomplete(
+        message = await self.model.acomplete(
             messages=self.format(*args, **kwargs),
             functions=self._functions,
             output_types=self._return_types,

--- a/src/magentic/prompt_chain.py
+++ b/src/magentic/prompt_chain.py
@@ -9,7 +9,7 @@ from typing import (
 )
 
 from magentic.chat import Chat
-from magentic.chat_model.openai_chat_model import OpenaiChatModel
+from magentic.chat_model.base import ChatModel
 from magentic.function_call import FunctionCall
 from magentic.prompt_function import AsyncPromptFunction, PromptFunction
 
@@ -24,7 +24,7 @@ class MaxFunctionCallsError(Exception):
 def prompt_chain(
     template: str,
     functions: list[Callable[..., Any]] | None = None,
-    model: OpenaiChatModel | None = None,
+    model: ChatModel | None = None,
     max_calls: int | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Convert a Python function to an LLM query, auto-resolving function calls."""

--- a/src/magentic/prompt_function.py
+++ b/src/magentic/prompt_function.py
@@ -14,8 +14,8 @@ from typing import (
 )
 
 from magentic.backend import get_chat_model
+from magentic.chat_model.base import ChatModel
 from magentic.chat_model.message import UserMessage
-from magentic.chat_model.openai_chat_model import OpenaiChatModel
 from magentic.function_call import FunctionCall
 from magentic.typing import is_origin_subclass, split_union_type
 
@@ -36,7 +36,7 @@ class BasePromptFunction(Generic[P, R]):
         parameters: Sequence[inspect.Parameter],
         return_type: type[R],
         functions: list[Callable[..., Any]] | None = None,
-        model: OpenaiChatModel | None = None,
+        model: ChatModel | None = None,
     ):
         self._signature = inspect.Signature(
             parameters=parameters,
@@ -57,7 +57,7 @@ class BasePromptFunction(Generic[P, R]):
         return self._functions.copy()
 
     @property
-    def model(self) -> OpenaiChatModel:
+    def model(self) -> ChatModel:
         return self._model or get_chat_model()
 
     @property
@@ -116,7 +116,7 @@ class PromptDecorator(Protocol):
 def prompt(
     template: str,
     functions: list[Callable[..., Any]] | None = None,
-    model: OpenaiChatModel | None = None,
+    model: ChatModel | None = None,
 ) -> PromptDecorator:
     """Convert a function into an LLM prompt template.
 

--- a/src/magentic/settings.py
+++ b/src/magentic/settings.py
@@ -1,9 +1,16 @@
+from enum import Enum
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Backend(Enum):
+    OPENAI = "openai"
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="MAGENTIC_")
 
+    backend: Backend = Backend.OPENAI
     openai_model: str = "gpt-3.5-turbo"
     openai_temperature: float | None = None
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -7,27 +7,15 @@ from magentic.chat_model.openai_chat_model import (
 )
 
 
-def test_openai_chat_model_model(monkeypatch):
+def test_backend_openai_chat_model(monkeypatch):
     monkeypatch.setenv("MAGENTIC_BACKEND", "openai")
     monkeypatch.setenv("MAGENTIC_OPENAI_MODEL", "gpt-4")
-    chat_model = get_chat_model()
-    assert isinstance(chat_model, OpenaiChatModel)
-    assert chat_model.model == "gpt-4"
-
-
-def test_openai_chat_model_max_tokens(monkeypatch):
-    monkeypatch.setenv("MAGENTIC_BACKEND", "openai")
     monkeypatch.setenv("MAGENTIC_OPENAI_MAX_TOKENS", "1024")
-    chat_model = get_chat_model()
-    assert isinstance(chat_model, OpenaiChatModel)
-    assert chat_model.max_tokens == 1024
-
-
-def test_openai_chat_model_temperature(monkeypatch):
-    monkeypatch.setenv("MAGENTIC_BACKEND", "openai")
     monkeypatch.setenv("MAGENTIC_OPENAI_TEMPERATURE", "2")
     chat_model = get_chat_model()
     assert isinstance(chat_model, OpenaiChatModel)
+    assert chat_model.model == "gpt-4"
+    assert chat_model.max_tokens == 1024
     assert chat_model.temperature == 2
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -10,17 +10,25 @@ from magentic.chat_model.openai_chat_model import (
 def test_openai_chat_model_model(monkeypatch):
     monkeypatch.setenv("MAGENTIC_BACKEND", "openai")
     monkeypatch.setenv("MAGENTIC_OPENAI_MODEL", "gpt-4")
-    assert get_chat_model().model == "gpt-4"
+    chat_model = get_chat_model()
+    assert isinstance(chat_model, OpenaiChatModel)
+    assert chat_model.model == "gpt-4"
 
 
 def test_openai_chat_model_max_tokens(monkeypatch):
+    monkeypatch.setenv("MAGENTIC_BACKEND", "openai")
     monkeypatch.setenv("MAGENTIC_OPENAI_MAX_TOKENS", "1024")
-    assert get_chat_model().max_tokens == 1024
+    chat_model = get_chat_model()
+    assert isinstance(chat_model, OpenaiChatModel)
+    assert chat_model.max_tokens == 1024
 
 
 def test_openai_chat_model_temperature(monkeypatch):
+    monkeypatch.setenv("MAGENTIC_BACKEND", "openai")
     monkeypatch.setenv("MAGENTIC_OPENAI_TEMPERATURE", "2")
-    assert get_chat_model().temperature == 2
+    chat_model = get_chat_model()
+    assert isinstance(chat_model, OpenaiChatModel)
+    assert chat_model.temperature == 2
 
 
 @pytest.mark.openai

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,13 +1,12 @@
-from magentic.chat_model.openai_chat_model import (
-    OpenaiChatModel,
-)
+from magentic.backend import get_chat_model
 
 
 def test_openai_chat_model_model(monkeypatch):
+    monkeypatch.setenv("MAGENTIC_BACKEND", "openai")
     monkeypatch.setenv("MAGENTIC_OPENAI_MODEL", "gpt-4")
-    assert OpenaiChatModel().model == "gpt-4"
+    assert get_chat_model().model == "gpt-4"
 
 
 def test_openai_chat_model_temperature(monkeypatch):
     monkeypatch.setenv("MAGENTIC_OPENAI_TEMPERATURE", "2")
-    assert OpenaiChatModel().temperature == 2
+    assert get_chat_model().temperature == 2


### PR DESCRIPTION
Create a `ChatModel` abstract base class. Use this for type hints. Others can implement this interface to use other backends/models.

Add a setting for choosing backend (currently just openai).

Resolves https://github.com/jackmpcollins/magentic/issues/32
