### PR TITLE
Handle pydantic generic BaseModel in name_type and function schema

### DIFF
--- a/src/magentic/chat_model/function_schema.py
+++ b/src/magentic/chat_model/function_schema.py
@@ -199,7 +199,7 @@ class BaseModelFunctionSchema(BaseFunctionSchema[BaseModelT], Generic[BaseModelT
 
     @property
     def name(self) -> str:
-        return f"return_{self._model.__name__.lower()}"
+        return f"return_{name_type(self._model)}"
 
     @property
     def parameters(self) -> dict[str, Any]:

--- a/src/magentic/typing.py
+++ b/src/magentic/typing.py
@@ -56,6 +56,14 @@ def name_type(type_: type) -> str:
         key_type, value_type = args
         return f"dict_of_{name_type(key_type)}_to_{name_type(value_type)}"
 
+    pydantic_metadata = getattr(type_, "__pydantic_generic_metadata__", None)
+    if (
+        pydantic_metadata
+        and (origin := pydantic_metadata.get("origin"))
+        and (args := pydantic_metadata.get("args"))
+    ):
+        return name_type(origin) + "_" + "_".join(name_type(arg) for arg in args)
+
     if name := getattr(type_, "__name__", None):
         assert isinstance(name, str)  # noqa: S101
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -77,6 +77,7 @@ class DoubleGenericModel(BaseModel, Generic[T1, T2]):
         (dict[str, int], "dict_of_str_to_int"),
         (typing.Iterable[str], "iterable_of_str"),
         (GenericModel[int], "genericmodel_int"),
+        (GenericModel[GenericModel[int]], "genericmodel_genericmodel_int"),
         (DoubleGenericModel[int, str], "doublegenericmodel_int_str"),
     ],
 )

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,8 +1,9 @@
 import typing
 from types import NoneType
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 import pytest
+from pydantic import BaseModel
 
 from magentic.typing import (
     is_origin_abstract,
@@ -51,6 +52,19 @@ def test_is_origin_subclass(type_, cls_or_tuple, expected_result):
     assert is_origin_subclass(type_, cls_or_tuple) == expected_result
 
 
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+
+
+class GenericModel(BaseModel, Generic[T1]):
+    one: T1
+
+
+class DoubleGenericModel(BaseModel, Generic[T1, T2]):
+    one: T1
+    two: T2
+
+
 @pytest.mark.parametrize(
     ("type_", "expected_name"),
     [
@@ -62,6 +76,8 @@ def test_is_origin_subclass(type_, cls_or_tuple, expected_result):
         (list[str] | bool, "list_of_str_or_bool"),
         (dict[str, int], "dict_of_str_to_int"),
         (typing.Iterable[str], "iterable_of_str"),
+        (GenericModel[int], "genericmodel_int"),
+        (DoubleGenericModel[int, str], "doublegenericmodel_int_str"),
     ],
 )
 def test_name_type(type_, expected_name):


### PR DESCRIPTION
Handle pydantic generic BaseModel in `name_type` and `BaseModelFunctionSchema`

Fixes https://github.com/jackmpcollins/magentic/issues/49
Closes https://github.com/jackmpcollins/magentic/pull/51