### PR TITLE
Allow ChatModel to be set with context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,15 +299,40 @@ print(len(out), time_elapsed, len(out) / time_elapsed)
 
 - The `functions` argument to `@prompt` can contain async/coroutine functions. When the corresponding `FunctionCall` objects are called the result must be awaited.
 - The `Annotated` type annotation can be used to provide descriptions and other metadata for function parameters. See [the pydantic documentation on using `Field` to describe function arguments](https://docs.pydantic.dev/latest/usage/validation_decorator/#using-field-to-describe-function-arguments).
-- The `@prompt` and `@prompt_chain` decorators also accept a `model` argument. You can pass an instance of `OpenaiChatModel` (from `magentic.chat_model.openai_chat_model`) to use GPT4 or configure a different temperature.
+- The `@prompt` and `@prompt_chain` decorators also accept a `model` argument. You can pass an instance of `OpenaiChatModel` to use GPT4 or configure a different temperature. See below.
 
 ## Configuration
 
-The order of precedence of configuration is
+The backend/LLM used by `magentic` can be configured in several ways. The order of precedence of configuration is
 
-1. Arguments passed when initializing an instance in Python
-2. Environment variables
-3. Default values from [src/magentic/settings.py](src/magentic/settings.py)
+1. Arguments explicitly passed when initializing an instance in Python
+1. Values set using a context manager in Python
+1. Environment variables
+1. Default values from [src/magentic/settings.py](src/magentic/settings.py)
+
+```python
+from magentic import OpenaiChatModel, prompt
+
+
+@prompt("Say hello")
+def say_hello() -> str:
+    ...
+
+
+@prompt(
+    "Say hello",
+    model=OpenaiChatModel("gpt-4", temperature=1),
+)
+def say_hello_gpt4() -> str:
+    ...
+
+
+say_hello()  # Uses env vars or default settings
+
+with OpenaiChatModel("gpt-3.5-turbo"):
+    say_hello()  # Uses gpt-3.5-turbo due to context manager
+    say_hello_gpt4()  # Uses gpt-4 with temperature=1 because explicitly configured
+```
 
 The following environment variables can be set.
 

--- a/src/magentic/__init__.py
+++ b/src/magentic/__init__.py
@@ -4,6 +4,7 @@ from magentic.chat_model.message import (
     SystemMessage,
     UserMessage,
 )
+from magentic.chat_model.openai_chat_model import OpenaiChatModel
 from magentic.chatprompt import chatprompt
 from magentic.function_call import FunctionCall
 from magentic.prompt_chain import prompt_chain
@@ -15,6 +16,7 @@ __all__ = [
     "FunctionResultMessage",
     "SystemMessage",
     "UserMessage",
+    "OpenaiChatModel",
     "chatprompt",
     "FunctionCall",
     "prompt_chain",

--- a/src/magentic/backend.py
+++ b/src/magentic/backend.py
@@ -1,8 +1,11 @@
-from magentic.chat_model.base import ChatModel
+from magentic.chat_model.base import ChatModel, _chat_model_context
 from magentic.settings import Backend, get_settings
 
 
 def get_chat_model() -> ChatModel:
+    if chat_model := _chat_model_context.get():
+        return chat_model
+
     settings = get_settings()
 
     match settings.backend:

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -2,7 +2,7 @@ import types
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from contextvars import ContextVar
-from typing import Any, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 from magentic.chat_model.message import (
     AssistantMessage,
@@ -13,6 +13,8 @@ from magentic.function_call import FunctionCall
 R = TypeVar("R")
 FuncR = TypeVar("FuncR")
 
+if TYPE_CHECKING:
+    _chat_model_context: ContextVar["ChatModel" | None]
 
 _chat_model_context = ContextVar("chat_model", default=None)
 

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -128,7 +128,7 @@ class ChatModel(ABC):
         """Async version of `complete`."""
         ...
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self.__token = _chat_model_context.set(self)
 
     def __exit__(
@@ -136,5 +136,5 @@ class ChatModel(ABC):
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
         traceback: types.TracebackType | None,
-    ):
+    ) -> None:
         _chat_model_context.reset(self.__token)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -30,3 +30,19 @@ def test_openai_chat_model_completion():
     assert isinstance(response, AssistantMessage)
     assert isinstance(response.content, str)
     # TODO: test for num_tokens here
+
+
+def test_chat_model_context():
+    chat_model = OpenaiChatModel("gpt-4")
+    with chat_model:
+        assert get_chat_model() is chat_model
+
+
+def test_chat_model_context_within_context():
+    with OpenaiChatModel("gpt-4"):
+        assert get_chat_model().model == "gpt-4"  # type: ignore[attr-defined]
+
+        with OpenaiChatModel("gpt-5"):
+            assert get_chat_model().model == "gpt-5"  # type: ignore[attr-defined]
+
+        assert get_chat_model().model == "gpt-4"  # type: ignore[attr-defined]


### PR DESCRIPTION
Allow the chat_model/LLM to be set using a context manager. This allows the same prompt-function to easily be reused with different models, and also makes it neater to dynamically set the model.


```python
from magentic import OpenaiChatModel, prompt


@prompt("Say hello")
def say_hello() -> str:
    ...


@prompt(
    "Say hello",
    model=OpenaiChatModel("gpt-4", temperature=1),
)
def say_hello_gpt4() -> str:
    ...


say_hello()  # Uses env vars or default settings

with OpenaiChatModel("gpt-3.5-turbo"):
    say_hello()  # Uses gpt-3.5-turbo due to context manager
    say_hello_gpt4()  # Uses gpt-4 with temperature=1 because explicitly configured
```