### PR TITLE
Fix outdated import in model configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,8 @@ The backend and LLM used by `magentic` can be configured in several ways. The or
 1. Default values from [src/magentic/settings.py](src/magentic/settings.py)
 
 ```python
-from magentic import OpenaiChatModel, prompt
+from magentic import prompt
+from magentic.chat_model.openai_chat_model import OpenaiChatModel
 from magentic.chat_model.litellm_chat_model import LitellmChatModel
 
 


### PR DESCRIPTION
`OpenaiChatModel` is no longer exported from the `magentic` package, so it needs to be imported from the `magentic.chat_model.openai_chat_model` package.