### PR TITLE
Add OpenAI seed param for deterministic sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ The following environment variables can be set.
 | MAGENTIC_OPENAI_API_TYPE     | Allowed options: "openai", "azure"     | azure                  |
 | MAGENTIC_OPENAI_BASE_URL     | Base URL for an OpenAI-compatible API  | http://localhost:8080  |
 | MAGENTIC_OPENAI_MAX_TOKENS   | OpenAI max number of generated tokens  | 1024                   |
+| MAGENTIC_OPENAI_SEED         | Seed for deterministic sampling        | 42                     |
 | MAGENTIC_OPENAI_TEMPERATURE  | OpenAI temperature                     | 0.5                    |
 
 When using the `openai` backend, setting the `MAGENTIC_OPENAI_BASE_URL` environment variable or using `OpenaiChatModel(..., base_url="http://localhost:8080")` in code allows you to use `magentic` with any OpenAI-compatible API e.g. [Azure OpenAI Service](https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart?tabs=command-line&pivots=programming-language-python#create-a-new-python-application), [LiteLLM OpenAI Proxy Server](https://docs.litellm.ai/docs/proxy_server), [LocalAI](https://localai.io/howtos/easy-request-openai/). Note that if the API does not support function calling then you will not be able to create prompt-functions that return Python objects, but other features of `magentic` will still work.

--- a/src/magentic/backend.py
+++ b/src/magentic/backend.py
@@ -26,6 +26,7 @@ def get_chat_model() -> ChatModel:
                 api_type=settings.openai_api_type,
                 base_url=settings.openai_base_url,
                 max_tokens=settings.openai_max_tokens,
+                seed=settings.openai_seed,
                 temperature=settings.openai_temperature,
             )
         case _:

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -90,6 +90,7 @@ def openai_chatcompletion_create(
     model: str,
     messages: list[ChatCompletionMessageParam],
     max_tokens: int | None = None,
+    seed: int | None = None,
     temperature: float | None = None,
     functions: list[dict[str, Any]] | None = None,
     function_call: Literal["auto", "none"] | dict[str, Any] | None = None,
@@ -116,6 +117,7 @@ def openai_chatcompletion_create(
         model=model,
         messages=messages,
         max_tokens=max_tokens,
+        seed=seed,
         temperature=temperature,
         stream=True,
         **kwargs,
@@ -129,6 +131,7 @@ async def openai_chatcompletion_acreate(
     model: str,
     messages: list[ChatCompletionMessageParam],
     max_tokens: int | None = None,
+    seed: int | None = None,
     temperature: float | None = None,
     functions: list[dict[str, Any]] | None = None,
     function_call: Literal["auto", "none"] | dict[str, Any] | None = None,
@@ -154,6 +157,7 @@ async def openai_chatcompletion_acreate(
         model=model,
         messages=messages,
         max_tokens=max_tokens,
+        seed=seed,
         temperature=temperature,
         stream=True,
         **kwargs,
@@ -175,12 +179,14 @@ class OpenaiChatModel(ChatModel):
         api_type: Literal["openai", "azure"] = "openai",
         base_url: str | None = None,
         max_tokens: int | None = None,
+        seed: int | None = None,
         temperature: float | None = None,
     ):
         self._model = model
         self._api_type = api_type
         self._base_url = base_url
         self._max_tokens = max_tokens
+        self._seed = seed
         self._temperature = temperature
 
     @property
@@ -198,6 +204,10 @@ class OpenaiChatModel(ChatModel):
     @property
     def max_tokens(self) -> int | None:
         return self._max_tokens
+
+    @property
+    def seed(self) -> int | None:
+        return self._seed
 
     @property
     def temperature(self) -> float | None:
@@ -272,6 +282,7 @@ class OpenaiChatModel(ChatModel):
             model=self.model,
             messages=[message_to_openai_message(m) for m in messages],
             max_tokens=self.max_tokens,
+            seed=self.seed,
             temperature=self.temperature,
             functions=openai_functions,
             function_call=(
@@ -399,6 +410,7 @@ class OpenaiChatModel(ChatModel):
             model=self.model,
             messages=[message_to_openai_message(m) for m in messages],
             max_tokens=self.max_tokens,
+            seed=self.seed,
             temperature=self.temperature,
             functions=openai_functions,
             function_call=(

--- a/src/magentic/settings.py
+++ b/src/magentic/settings.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     openai_api_type: Literal["openai", "azure"] = "openai"
     openai_base_url: str | None = None
     openai_max_tokens: int | None = None
+    openai_seed: int | None = None
     openai_temperature: float | None = None
 
 

--- a/tests/chat_model/test_openai_chat_model.py
+++ b/tests/chat_model/test_openai_chat_model.py
@@ -9,3 +9,11 @@ def test_openai_chat_model_complete_base_url():
     chat_model = OpenaiChatModel("gpt-3.5-turbo", base_url="https://api.openai.com/v1")
     message = chat_model.complete(messages=[UserMessage("Say hello!")])
     assert isinstance(message.content, str)
+
+
+@pytest.mark.openai
+def test_openai_chat_model_complete_seed():
+    chat_model = OpenaiChatModel("gpt-3.5-turbo", seed=42)
+    message1 = chat_model.complete(messages=[UserMessage("Say hello!")])
+    message2 = chat_model.complete(messages=[UserMessage("Say hello!")])
+    assert message1.content == message2.content

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -14,6 +14,7 @@ def test_backend_openai_chat_model(monkeypatch):
     monkeypatch.setenv("MAGENTIC_OPENAI_API_TYPE", "azure")
     monkeypatch.setenv("MAGENTIC_OPENAI_BASE_URL", "http://localhost:8080")
     monkeypatch.setenv("MAGENTIC_OPENAI_MAX_TOKENS", "1024")
+    monkeypatch.setenv("MAGENTIC_OPENAI_SEED", "42")
     monkeypatch.setenv("MAGENTIC_OPENAI_TEMPERATURE", "2")
     chat_model = get_chat_model()
     assert isinstance(chat_model, OpenaiChatModel)
@@ -21,6 +22,7 @@ def test_backend_openai_chat_model(monkeypatch):
     assert chat_model.api_type == "azure"
     assert chat_model.base_url == "http://localhost:8080"
     assert chat_model.max_tokens == 1024
+    assert chat_model.seed == 42
     assert chat_model.temperature == 2
 
 


### PR DESCRIPTION
Add OpenAI seed param for deterministic sampling. Set this using env var `MAGENTIC_OPENAI_SEED`, or in code with `OpenaiChatModel(..., seed=42)`.

Resolves https://github.com/jackmpcollins/magentic/issues/68