### PR TITLE
Add stop param

### DIFF
--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -97,6 +97,8 @@ class ChatModel(ABC):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[str]:
         ...
 
@@ -107,6 +109,8 @@ class ChatModel(ABC):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
         ...
 
@@ -117,6 +121,8 @@ class ChatModel(ABC):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: Iterable[type[R]] = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[R]:
         ...
 
@@ -127,6 +133,8 @@ class ChatModel(ABC):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: Iterable[type[R]],
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
         ...
 
@@ -136,6 +144,8 @@ class ChatModel(ABC):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
+        *,
+        stop: list[str] | None = None,
     ) -> (
         AssistantMessage[FunctionCall[FuncR]]
         | AssistantMessage[R]

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -32,6 +32,7 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: None = ...,
+        stop: list[str] | None = None,
         output_types: None = ...,
     ) -> AssistantMessage[str]:
         ...
@@ -42,6 +43,7 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
+        stop: list[str] | None = None,
         output_types: None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
         ...
@@ -52,6 +54,7 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: None = ...,
+        stop: list[str] | None = None,
         output_types: Iterable[type[R]] = ...,
     ) -> AssistantMessage[R]:
         ...
@@ -62,6 +65,7 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
+        stop: list[str],
         output_types: Iterable[type[R]],
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
         ...
@@ -71,6 +75,7 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
+        stop: list[str] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
     ) -> (
         AssistantMessage[FunctionCall[FuncR]]

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -32,8 +32,9 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: None = ...,
-        stop: list[str] | None = None,
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[str]:
         ...
 
@@ -43,8 +44,9 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
-        stop: list[str] | None = None,
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
         ...
 
@@ -54,8 +56,9 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: None = ...,
-        stop: list[str] | None = None,
         output_types: Iterable[type[R]] = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[R]:
         ...
 
@@ -65,8 +68,9 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
-        stop: list[str],
         output_types: Iterable[type[R]],
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
         ...
 
@@ -75,8 +79,9 @@ class ChatModel(ABC):
         self,
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
-        stop: list[str] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
+        *,
+        stop: list[str] | None = None,
     ) -> (
         AssistantMessage[FunctionCall[FuncR]]
         | AssistantMessage[R]

--- a/src/magentic/chat_model/litellm_chat_model.py
+++ b/src/magentic/chat_model/litellm_chat_model.py
@@ -38,6 +38,7 @@ def litellm_completion(
     messages: list[ChatCompletionMessageParam],
     api_base: str | None = None,
     max_tokens: int | None = None,
+    stop: list[str] | None = None,
     temperature: float | None = None,
     functions: list[dict[str, Any]] | None = None,
     function_call: Literal["auto", "none"] | dict[str, Any] | None = None,
@@ -60,6 +61,7 @@ def litellm_completion(
     response: CustomStreamWrapper = litellm.completion(  # type: ignore[no-untyped-call,unused-ignore]
         model=model,
         messages=messages,
+        stop=stop,
         stream=True,
         **kwargs,
     )
@@ -71,6 +73,7 @@ async def litellm_acompletion(
     messages: list[ChatCompletionMessageParam],
     api_base: str | None = None,
     max_tokens: int | None = None,
+    stop: list[str] | None = None,
     temperature: float | None = None,
     functions: list[dict[str, Any]] | None = None,
     function_call: Literal["auto", "none"] | dict[str, Any] | None = None,
@@ -93,6 +96,7 @@ async def litellm_acompletion(
     response: AsyncIterator[ModelResponse] = await litellm.acompletion(  # type: ignore[no-untyped-call,unused-ignore]
         model=model,
         messages=messages,
+        stop=stop,
         stream=True,
         **kwargs,
     )
@@ -141,6 +145,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[str]:
         ...
 
@@ -150,6 +156,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
         ...
 
@@ -159,6 +167,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: Iterable[type[R]] = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[R]:
         ...
 
@@ -168,6 +178,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: Iterable[type[R]],
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
         ...
 
@@ -176,6 +188,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
+        *,
+        stop: list[str] | None = None,
     ) -> (
         AssistantMessage[FunctionCall[FuncR]]
         | AssistantMessage[R]
@@ -203,6 +217,7 @@ class LitellmChatModel(ChatModel):
             messages=[message_to_openai_message(m) for m in messages],
             api_base=self.api_base,
             max_tokens=self.max_tokens,
+            stop=stop,
             temperature=self.temperature,
             functions=openai_functions,
             function_call=(
@@ -262,6 +277,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[str]:
         ...
 
@@ -271,6 +288,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
         ...
 
@@ -280,6 +299,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: Iterable[type[R]] = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[R]:
         ...
 
@@ -289,6 +310,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: Iterable[type[R]],
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
         ...
 
@@ -297,6 +320,8 @@ class LitellmChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
+        *,
+        stop: list[str] | None = None,
     ) -> (
         AssistantMessage[FunctionCall[FuncR]]
         | AssistantMessage[R]
@@ -324,6 +349,7 @@ class LitellmChatModel(ChatModel):
             messages=[message_to_openai_message(m) for m in messages],
             api_base=self.api_base,
             max_tokens=self.max_tokens,
+            stop=stop,
             temperature=self.temperature,
             functions=openai_functions,
             function_call=(

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -138,6 +138,7 @@ async def openai_chatcompletion_acreate(
     messages: list[ChatCompletionMessageParam],
     max_tokens: int | None = None,
     seed: int | None = None,
+    stop: list[str] | None = None,
     temperature: float | None = None,
     functions: list[dict[str, Any]] | None = None,
     function_call: Literal["auto", "none"] | dict[str, Any] | None = None,
@@ -166,6 +167,7 @@ async def openai_chatcompletion_acreate(
         messages=messages,
         max_tokens=max_tokens,
         seed=seed,
+        stop=stop,
         temperature=temperature,
         stream=True,
         **kwargs,
@@ -373,6 +375,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[str]:
         ...
 
@@ -382,6 +386,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
         ...
 
@@ -391,6 +397,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: Iterable[type[R]] = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[R]:
         ...
 
@@ -400,6 +408,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: Iterable[type[R]],
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
         ...
 
@@ -408,6 +418,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
+        *,
+        stop: list[str] | None = None,
     ) -> (
         AssistantMessage[FunctionCall[FuncR]]
         | AssistantMessage[R]
@@ -438,6 +450,7 @@ class OpenaiChatModel(ChatModel):
             messages=[message_to_openai_message(m) for m in messages],
             max_tokens=self.max_tokens,
             seed=self.seed,
+            stop=stop,
             temperature=self.temperature,
             functions=openai_functions,
             function_call=(

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -233,6 +233,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[str]:
         ...
 
@@ -242,6 +244,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: None = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[str]:
         ...
 
@@ -251,6 +255,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: None = ...,
         output_types: Iterable[type[R]] = ...,
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[R]:
         ...
 
@@ -260,6 +266,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]],
         output_types: Iterable[type[R]],
+        *,
+        stop: list[str] | None = ...,
     ) -> AssistantMessage[FunctionCall[FuncR]] | AssistantMessage[R]:
         ...
 
@@ -268,7 +276,8 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
-        stop: Iterable[str] | None = None,
+        *,
+        stop: list[str] | None = None,
     ) -> (
         AssistantMessage[FunctionCall[FuncR]]
         | AssistantMessage[R]

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -93,6 +93,7 @@ def openai_chatcompletion_create(
     max_tokens: int | None = None,
     seed: int | None = None,
     temperature: float | None = None,
+    stop: list[str] | None = None,
     functions: list[dict[str, Any]] | None = None,
     function_call: Literal["auto", "none"] | dict[str, Any] | None = None,
 ) -> Iterator[ChatCompletionChunk]:
@@ -123,6 +124,7 @@ def openai_chatcompletion_create(
         seed=seed,
         temperature=temperature,
         stream=True,
+        stop=stop,
         **kwargs,
     )
     return response
@@ -266,6 +268,7 @@ class OpenaiChatModel(ChatModel):
         messages: Iterable[Message[Any]],
         functions: Iterable[Callable[..., FuncR]] | None = None,
         output_types: Iterable[type[R | str]] | None = None,
+        stop: Iterable[str] | None = None,
     ) -> (
         AssistantMessage[FunctionCall[FuncR]]
         | AssistantMessage[R]
@@ -297,6 +300,7 @@ class OpenaiChatModel(ChatModel):
             max_tokens=self.max_tokens,
             seed=self.seed,
             temperature=self.temperature,
+            stop=stop,
             functions=openai_functions,
             function_call=(
                 {"name": openai_functions[0]["name"]}

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -92,8 +92,8 @@ def openai_chatcompletion_create(
     messages: list[ChatCompletionMessageParam],
     max_tokens: int | None = None,
     seed: int | None = None,
-    temperature: float | None = None,
     stop: list[str] | None = None,
+    temperature: float | None = None,
     functions: list[dict[str, Any]] | None = None,
     function_call: Literal["auto", "none"] | dict[str, Any] | None = None,
 ) -> Iterator[ChatCompletionChunk]:
@@ -122,9 +122,9 @@ def openai_chatcompletion_create(
         messages=messages,
         max_tokens=max_tokens,
         seed=seed,
-        temperature=temperature,
-        stream=True,
         stop=stop,
+        stream=True,
+        temperature=temperature,
         **kwargs,
     )
     return response
@@ -299,8 +299,8 @@ class OpenaiChatModel(ChatModel):
             messages=[message_to_openai_message(m) for m in messages],
             max_tokens=self.max_tokens,
             seed=self.seed,
-            temperature=self.temperature,
             stop=stop,
+            temperature=self.temperature,
             functions=openai_functions,
             function_call=(
                 {"name": openai_functions[0]["name"]}

--- a/src/magentic/chatprompt.py
+++ b/src/magentic/chatprompt.py
@@ -54,8 +54,8 @@ class BaseChatPromptFunction(Generic[P, R]):
         )
         self._messages = messages
         self._functions = functions or []
-        self._model = model
         self._stop = stop
+        self._model = model
 
         self._return_types = [
             type_
@@ -99,8 +99,8 @@ class ChatPromptFunction(BaseChatPromptFunction[P, R], Generic[P, R]):
         message = self.model.complete(
             messages=self.format(*args, **kwargs),
             functions=self._functions,
-            stop=self._stop,
             output_types=self._return_types,
+            stop=self._stop,
         )
         return cast(R, message.content)
 

--- a/src/magentic/chatprompt.py
+++ b/src/magentic/chatprompt.py
@@ -114,6 +114,7 @@ class AsyncChatPromptFunction(BaseChatPromptFunction[P, R], Generic[P, R]):
             messages=self.format(*args, **kwargs),
             functions=self._functions,
             output_types=self._return_types,
+            stop=self._stop,
         )
         return cast(R, message.content)
 
@@ -188,6 +189,7 @@ def chatprompt(
                 parameters=list(func_signature.parameters.values()),
                 return_type=func_signature.return_annotation,
                 functions=functions,
+                stop=stop,
                 model=model,
             )
             async_prompt_function = update_wrapper(async_prompt_function, func)

--- a/src/magentic/prompt_function.py
+++ b/src/magentic/prompt_function.py
@@ -85,9 +85,9 @@ class PromptFunction(BasePromptFunction[P, R], Generic[P, R]):
         """Query the LLM with the formatted prompt template."""
         message = self.model.complete(
             messages=[UserMessage(content=self.format(*args, **kwargs))],
-            stop=self._stop,
             functions=self._functions,
             output_types=self._return_types,
+            stop=self._stop,
         )
         return cast(R, message.content)
 

--- a/src/magentic/prompt_function.py
+++ b/src/magentic/prompt_function.py
@@ -101,6 +101,7 @@ class AsyncPromptFunction(BasePromptFunction[P, R], Generic[P, R]):
             messages=[UserMessage(content=self.format(*args, **kwargs))],
             functions=self._functions,
             output_types=self._return_types,
+            stop=self._stop,
         )
         return cast(R, message.content)
 
@@ -154,6 +155,7 @@ def prompt(
                 parameters=list(func_signature.parameters.values()),
                 return_type=func_signature.return_annotation,
                 functions=functions,
+                stop=stop,
                 model=model,
             )
             async_prompt_function = update_wrapper(async_prompt_function, func)

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -76,6 +76,7 @@ def test_chatpromptfunction_call():
 
     @chatprompt(
         UserMessage("Hello {name}."),
+        stop=["stop"],
         model=mock_model,
     )
     def say_hello(name: str) -> str | bool:
@@ -87,6 +88,7 @@ def test_chatpromptfunction_call():
         UserMessage("Hello World.")
     ]
     assert mock_model.complete.call_args.kwargs["output_types"] == [str, bool]
+    assert mock_model.complete.call_args.kwargs["stop"] == ["stop"]
 
 
 def test_chatprompt_decorator_docstring():
@@ -106,6 +108,7 @@ async def test_asyncchatpromptfunction_call():
 
     @chatprompt(
         UserMessage("Hello {name}."),
+        stop=["stop"],
         model=mock_model,
     )
     async def say_hello(name: str) -> str | bool:
@@ -117,6 +120,7 @@ async def test_asyncchatpromptfunction_call():
         UserMessage("Hello World.")
     ]
     assert mock_model.acomplete.call_args.kwargs["output_types"] == [str, bool]
+    assert mock_model.acomplete.call_args.kwargs["stop"] == ["stop"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Resolves https://github.com/jackmpcollins/magentic/issues/79

Add `stop` param to enable stopping token generation, for both `@prompt` and `@chatprompt`.

---

```python
from magentic import prompt


@prompt(
    "Say the alphabet",
    stop=["G"],
)
def say_alphabet() -> str:
    ...


say_alphabet()
# 'A B C D E F '
```
