### PR TITLE
Use Ellipses in functions with docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ ignore = [
    "COM",  # flake8-commas
     "FA",  # flake8-future-annotations
    "INP",  # flake8-no-pep420
+"PIE790",  # flake8-pie: Unnecessary `...` literal
    "SLF",  # flake8-self
    "ARG",  # flake8-unused-arguments
     "TD",  # flake8-todos

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -95,6 +95,7 @@ def test_chatprompt_decorator_docstring():
     @chatprompt(UserMessage("This is a user message."))
     def func(one: int) -> str:
         """This is the docstring."""
+        ...
 
     assert isinstance(func, ChatPromptFunction)
     assert getdoc(func) == "This is the docstring."
@@ -127,6 +128,7 @@ async def test_async_chatprompt_decorator_docstring():
     @chatprompt(UserMessage("This is a user message."))
     async def func(one: int) -> str:
         """This is the docstring."""
+        ...
 
     assert isinstance(func, AsyncChatPromptFunction)
     assert getdoc(func) == "This is the docstring."


### PR DESCRIPTION
Resolve pyright error for return type not being met by adding `...` back to test functions.
Make ruff ignore unnecessary `...`