### PR TITLE
Add format method to Message. Allow registering new types with message_to_openai_message

### DIFF
--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -5,7 +5,6 @@ from typing import (
     Generic,
     TypeVar,
     cast,
-    get_args,
     get_origin,
     overload,
 )
@@ -16,20 +15,16 @@ T = TypeVar("T")
 
 
 class Placeholder(Generic[T]):
-    def __init__(self, name: str):
+    def __init__(self, type_: type[T], name: str):
+        self.type_ = type_
         self.name = name
 
     def format(self, **kwargs: Any) -> T:
         value = kwargs[self.name]
-        if not isinstance(value, self._get_type()):
-            msg = f"{self.name} must be of type {self._get_type()}"
+        if not isinstance(value, get_origin(self.type_) or self.type_):
+            msg = f"{self.name} must be of type {self.type_}"
             raise TypeError(msg)
-        return value
-
-    @classmethod
-    def _get_type(cls) -> type[T]:
-        type_ = get_origin(get_args(cls)[0])
-        return cast(type[T], type_)
+        return cast(T, value)
 
 
 ContentT = TypeVar("ContentT")

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Awaitable, Generic, TypeVar, overload
+from typing import Any, Awaitable, Generic, TypeVar, cast, overload
 
 from magentic.function_call import FunctionCall
 
@@ -61,7 +61,9 @@ class AssistantMessage(Message[T], Generic[T]):
 
     def format(self, **kwargs: Any) -> "AssistantMessage[T]":
         if isinstance(self.content, str):
-            return self.with_content(self.content.format(**kwargs))
+            # Cast back to more general type `T` to satisfy mypy
+            content = cast(T, self.content.format(**kwargs))
+            return self.with_content(content)
         return self
 
 
@@ -94,7 +96,9 @@ class FunctionResultMessage(Message[T], Generic[T]):
 
     def format(self, **kwargs: Any) -> "FunctionResultMessage[T]":
         if isinstance(self.content, str):
-            return self.with_content(self.content.format(**kwargs))
+            # Cast back to more general type `T` to sa
+            content = cast(T, self.content.format(**kwargs))
+            return self.with_content(content)
         return self
 
     @classmethod

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -78,7 +78,5 @@ class FunctionResultMessage(Message[ContentT], Generic[ContentT]):
         return self._function
 
     def format(self, **kwargs: Any) -> "FunctionResultMessage[ContentT]":
-        if isinstance(self.content, str):
-            content = cast(ContentT, self.content.format(**kwargs))
-            return FunctionResultMessage(content, self.function)
+        del kwargs
         return FunctionResultMessage(self.content, self.function)

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Awaitable, Generic, TypeVar, overload
+from typing import Any, Awaitable, Generic, TypeVar, overload
 
 from magentic.function_call import FunctionCall
 
@@ -29,7 +29,7 @@ class Message(Generic[T], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def format(self, *args, **kwargs) -> "Message[T]":
+    def format(self, **kwargs: Any) -> "Message[T]":
         raise NotImplementedError
 
 
@@ -39,8 +39,8 @@ class SystemMessage(Message[str]):
     def with_content(self, content: str) -> "SystemMessage":
         return SystemMessage(content)
 
-    def format(self, *args, **kwargs) -> "SystemMessage":
-        return self.with_content(self.content.format(*args, **kwargs))
+    def format(self, **kwargs: Any) -> "SystemMessage":
+        return self.with_content(self.content.format(**kwargs))
 
 
 class UserMessage(Message[str]):
@@ -49,8 +49,8 @@ class UserMessage(Message[str]):
     def with_content(self, content: str) -> "UserMessage":
         return UserMessage(content)
 
-    def format(self, *args, **kwargs) -> "UserMessage":
-        return self.with_content(self.content.format(*args, **kwargs))
+    def format(self, **kwargs: Any) -> "UserMessage":
+        return self.with_content(self.content.format(**kwargs))
 
 
 class AssistantMessage(Message[T], Generic[T]):
@@ -59,10 +59,10 @@ class AssistantMessage(Message[T], Generic[T]):
     def with_content(self, content: T) -> "AssistantMessage[T]":
         return AssistantMessage(content)
 
-    def format(self, *args, **kwargs) -> "AssistantMessage[T]":
+    def format(self, **kwargs: Any) -> "AssistantMessage[T]":
         if isinstance(self.content, str):
-            return self.with_content(self.content.format(*args, **kwargs))
-        return self  # TODO: Handle `Placeholder` here?
+            return self.with_content(self.content.format(**kwargs))
+        return self
 
 
 class FunctionResultMessage(Message[T], Generic[T]):
@@ -92,10 +92,10 @@ class FunctionResultMessage(Message[T], Generic[T]):
     def with_content(self, content: T) -> "FunctionResultMessage[T]":
         return FunctionResultMessage(content, self._function_call)
 
-    def format(self, *args, **kwargs) -> "FunctionResultMessage[T]":
+    def format(self, **kwargs: Any) -> "FunctionResultMessage[T]":
         if isinstance(self.content, str):
-            return self.with_content(self.content.format(*args, **kwargs))
-        return self  # TODO: Handle `Placeholder` here?
+            return self.with_content(self.content.format(**kwargs))
+        return self
 
     @classmethod
     def from_function_call(

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -46,18 +46,12 @@ def message_to_openai_message(message: Message[Any]) -> ChatCompletionMessagePar
 
 @message_to_openai_message.register
 def _(message: SystemMessage) -> ChatCompletionMessageParam:
-    return {
-        "role": OpenaiMessageRole.SYSTEM.value,
-        "content": message.content,
-    }
+    return {"role": OpenaiMessageRole.SYSTEM.value, "content": message.content}
 
 
 @message_to_openai_message.register
 def _(message: UserMessage) -> ChatCompletionMessageParam:
-    return {
-        "role": OpenaiMessageRole.USER.value,
-        "content": message.content,
-    }
+    return {"role": OpenaiMessageRole.USER.value, "content": message.content}
 
 
 @message_to_openai_message.register(AssistantMessage)

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -116,13 +116,15 @@ def openai_chatcompletion_create(
         kwargs["functions"] = functions
     if function_call:
         kwargs["function_call"] = function_call
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+    if stop is not None:
+        kwargs["stop"] = stop
 
     response: Iterator[ChatCompletionChunk] = client.chat.completions.create(
         model=model,
         messages=messages,
-        max_tokens=max_tokens,
         seed=seed,
-        stop=stop,
         stream=True,
         temperature=temperature,
         **kwargs,
@@ -161,13 +163,15 @@ async def openai_chatcompletion_acreate(
         kwargs["functions"] = functions
     if function_call:
         kwargs["function_call"] = function_call
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+    if stop is not None:
+        kwargs["stop"] = stop
 
     response: AsyncIterator[ChatCompletionChunk] = await client.chat.completions.create(
         model=model,
         messages=messages,
-        max_tokens=max_tokens,
         seed=seed,
-        stop=stop,
         temperature=temperature,
         stream=True,
         **kwargs,

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -41,6 +41,7 @@ class OpenaiMessageRole(Enum):
 @singledispatch
 def message_to_openai_message(message: Message[Any]) -> ChatCompletionMessageParam:
     """Convert a Message to an OpenAI message."""
+    # TODO: Add instructions for registering new Message type to this error message
     raise NotImplementedError(type(message))
 
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator
 from enum import Enum
+from functools import singledispatch
 from itertools import chain
 from typing import Any, Literal, TypeVar, cast, overload
 
@@ -37,51 +38,60 @@ class OpenaiMessageRole(Enum):
     USER = "user"
 
 
+@singledispatch
 def message_to_openai_message(message: Message[Any]) -> ChatCompletionMessageParam:
     """Convert a Message to an OpenAI message."""
-    if isinstance(message, SystemMessage):
-        return {
-            "role": OpenaiMessageRole.SYSTEM.value,
-            "content": message.content,
-        }
+    raise NotImplementedError(type(message))
 
-    if isinstance(message, UserMessage):
-        return {
-            "role": OpenaiMessageRole.USER.value,
-            "content": message.content,
-        }
 
-    if isinstance(message, AssistantMessage):
-        if isinstance(message.content, str):
-            return {
-                "role": OpenaiMessageRole.ASSISTANT.value,
-                "content": message.content,
-            }
+@message_to_openai_message.register
+def _(message: SystemMessage) -> ChatCompletionMessageParam:
+    return {
+        "role": OpenaiMessageRole.SYSTEM.value,
+        "content": message.content,
+    }
 
-        function_schema: BaseFunctionSchema[Any]
-        if isinstance(message.content, FunctionCall):
-            function_schema = FunctionCallFunctionSchema(message.content.function)
-        else:
-            function_schema = function_schema_for_type(type(message.content))
 
+@message_to_openai_message.register
+def _(message: UserMessage) -> ChatCompletionMessageParam:
+    return {
+        "role": OpenaiMessageRole.USER.value,
+        "content": message.content,
+    }
+
+
+@message_to_openai_message.register(AssistantMessage)
+def _(message: AssistantMessage[Any]) -> ChatCompletionMessageParam:
+    if isinstance(message.content, str):
         return {
             "role": OpenaiMessageRole.ASSISTANT.value,
-            "content": None,
-            "function_call": {
-                "name": function_schema.name,
-                "arguments": function_schema.serialize_args(message.content),
-            },
+            "content": message.content,
         }
 
-    if isinstance(message, FunctionResultMessage):
+    function_schema: BaseFunctionSchema[Any]
+    if isinstance(message.content, FunctionCall):
+        function_schema = FunctionCallFunctionSchema(message.content.function)
+    else:
         function_schema = function_schema_for_type(type(message.content))
-        return {
-            "role": OpenaiMessageRole.FUNCTION.value,
-            "name": FunctionCallFunctionSchema(message.function).name,
-            "content": function_schema.serialize_args(message.content),
-        }
 
-    raise NotImplementedError(type(message))
+    return {
+        "role": OpenaiMessageRole.ASSISTANT.value,
+        "content": None,
+        "function_call": {
+            "name": function_schema.name,
+            "arguments": function_schema.serialize_args(message.content),
+        },
+    }
+
+
+@message_to_openai_message.register(FunctionResultMessage)
+def _(message: FunctionResultMessage[Any]) -> ChatCompletionMessageParam:
+    function_schema = function_schema_for_type(type(message.content))
+    return {
+        "role": OpenaiMessageRole.FUNCTION.value,
+        "name": FunctionCallFunctionSchema(message.function).name,
+        "content": function_schema.serialize_args(message.content),
+    }
 
 
 def openai_chatcompletion_create(

--- a/src/magentic/chatprompt.py
+++ b/src/magentic/chatprompt.py
@@ -79,16 +79,10 @@ class BaseChatPromptFunction(Generic[P, R]):
         """Format the message templates with the given arguments."""
         bound_args = self._signature.bind(*args, **kwargs)
         bound_args.apply_defaults()
-
-        messages = []
-        for message_template in self._messages:
-            if isinstance(message_template.content, str):
-                content = message_template.content.format(**bound_args.arguments)
-                messages.append(message_template.with_content(content))
-            else:
-                messages.append(message_template)
-
-        return messages
+        return [
+            message_template.format(**bound_args.arguments)
+            for message_template in self._messages
+        ]
 
 
 class ChatPromptFunction(BaseChatPromptFunction[P, R], Generic[P, R]):

--- a/tests/chat_model/test_message.py
+++ b/tests/chat_model/test_message.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel
+from typing_extensions import assert_type
+
+from magentic.chat_model.message import AssistantMessage, Placeholder, UserMessage
+
+
+def test_placeholder():
+    class Country(BaseModel):
+        name: str
+
+    placeholder = Placeholder(Country, "country")
+
+    assert_type(placeholder, Placeholder[Country])
+    assert placeholder.name == "country"
+
+
+def test_user_message_format():
+    user_message = UserMessage("Hello {x}")
+    user_message_formatted = user_message.format(x="world")
+
+    assert_type(user_message_formatted, UserMessage)
+    assert_type(user_message_formatted.content, str)
+    assert user_message_formatted == UserMessage("Hello world")
+
+
+def test_assistant_message_format():
+    class Country(BaseModel):
+        name: str
+
+    assistant_message = AssistantMessage(Placeholder(Country, "country"))
+    assistant_message_formatted = assistant_message.format(country=Country(name="USA"))
+
+    assert_type(assistant_message_formatted, AssistantMessage[Country])
+    assert_type(assistant_message_formatted.content, Country)
+    assert assistant_message_formatted == AssistantMessage(Country(name="USA"))

--- a/tests/chat_model/test_message.py
+++ b/tests/chat_model/test_message.py
@@ -4,19 +4,8 @@ from typing_extensions import assert_type
 from magentic.chat_model.message import (
     AssistantMessage,
     FunctionResultMessage,
-    Placeholder,
     UserMessage,
 )
-
-
-def test_placeholder():
-    class Country(BaseModel):
-        name: str
-
-    placeholder = Placeholder(Country, "country")
-
-    assert_type(placeholder, Placeholder[Country])
-    assert placeholder.name == "country"
 
 
 def test_user_message_format():
@@ -32,8 +21,8 @@ def test_assistant_message_format():
     class Country(BaseModel):
         name: str
 
-    assistant_message = AssistantMessage(Placeholder(Country, "country"))
-    assistant_message_formatted = assistant_message.format(country=Country(name="USA"))
+    assistant_message = AssistantMessage(Country(name="USA"))
+    assistant_message_formatted = assistant_message.format(foo="bar")
 
     assert_type(assistant_message_formatted, AssistantMessage[Country])
     assert_type(assistant_message_formatted.content, Country)

--- a/tests/chat_model/test_message.py
+++ b/tests/chat_model/test_message.py
@@ -17,6 +17,15 @@ def test_user_message_format():
     assert user_message_formatted == UserMessage("Hello world")
 
 
+def test_assistant_message_format_str():
+    assistant_message = AssistantMessage("Hello {x}")
+    assistant_message_formatted = assistant_message.format(x="world")
+
+    assert_type(assistant_message_formatted, AssistantMessage[str])
+    assert_type(assistant_message_formatted.content, str)
+    assert assistant_message_formatted == AssistantMessage("Hello world")
+
+
 def test_assistant_message_format():
     class Country(BaseModel):
         name: str

--- a/tests/chat_model/test_message.py
+++ b/tests/chat_model/test_message.py
@@ -1,7 +1,12 @@
 from pydantic import BaseModel
 from typing_extensions import assert_type
 
-from magentic.chat_model.message import AssistantMessage, Placeholder, UserMessage
+from magentic.chat_model.message import (
+    AssistantMessage,
+    FunctionResultMessage,
+    Placeholder,
+    UserMessage,
+)
 
 
 def test_placeholder():
@@ -33,3 +38,15 @@ def test_assistant_message_format():
     assert_type(assistant_message_formatted, AssistantMessage[Country])
     assert_type(assistant_message_formatted.content, Country)
     assert assistant_message_formatted == AssistantMessage(Country(name="USA"))
+
+
+def test_function_result_message_format():
+    def plus(a: int, b: int) -> int:
+        return a + b
+
+    function_result_message = FunctionResultMessage(3, plus)
+    function_result_message_formatted = function_result_message.format(foo="bar")
+
+    assert_type(function_result_message_formatted, FunctionResultMessage[int])
+    assert_type(function_result_message_formatted.content, int)
+    assert function_result_message_formatted == FunctionResultMessage(3, plus)

--- a/tests/chat_model/test_openai_chat_model.py
+++ b/tests/chat_model/test_openai_chat_model.py
@@ -6,6 +6,7 @@ import pytest
 from magentic.chat_model.message import (
     AssistantMessage,
     FunctionResultMessage,
+    Message,
     SystemMessage,
     UserMessage,
 )
@@ -54,6 +55,16 @@ def plus(a: int, b: int) -> int:
 )
 def test_message_to_openai_message(message, expected_openai_message):
     assert message_to_openai_message(message) == expected_openai_message
+
+
+def test_message_to_openai_message_raises():
+    class CustomMessage(Message[str]):
+        def format(self, **kwargs):
+            del kwargs
+            return CustomMessage(self.content)
+
+    with pytest.raises(NotImplementedError):
+        message_to_openai_message(CustomMessage("Hello"))
 
 
 @pytest.mark.openai

--- a/tests/chat_model/test_openai_chat_model.py
+++ b/tests/chat_model/test_openai_chat_model.py
@@ -2,6 +2,7 @@ import os
 
 import openai
 import pytest
+from openai.types.chat import ChatCompletionMessageParam
 
 from magentic.chat_model.message import (
     AssistantMessage,
@@ -65,6 +66,15 @@ def test_message_to_openai_message_raises():
 
     with pytest.raises(NotImplementedError):
         message_to_openai_message(CustomMessage("Hello"))
+
+    @message_to_openai_message.register
+    def _(message: CustomMessage) -> ChatCompletionMessageParam:
+        return {"role": "user", "content": message.content}
+
+    assert message_to_openai_message(CustomMessage("Hello")) == {
+        "role": "user",
+        "content": "Hello",
+    }
 
 
 @pytest.mark.openai

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -49,6 +49,7 @@ def test_escape_braces(text):
             [AssistantMessage("Assistant message with {param}.")],
             [AssistantMessage("Assistant message with arg.")],
         ),
+        # Do not format FunctionResultMessage
         (
             [
                 FunctionResultMessage(
@@ -57,7 +58,7 @@ def test_escape_braces(text):
             ],
             [
                 FunctionResultMessage(
-                    "Function result message with arg", function=Mock()
+                    "Function result message with {param}", function=Mock()
                 )
             ],
         ),


### PR DESCRIPTION
Groundwork for enabling adding more `Message` subclasses, with any formatting logic. This is to support adding message types for gpt4-vision (issue https://github.com/jackmpcollins/magentic/issues/58), and possibly placeholders within these for inserting values more generally than the string formatting currently supported.

- Add `format` method to `Message` class, replacing `with_content`
- Use `singledispatch` for `message_to_openai_message` to allow extending with new `Message` subclasses

Also move some optional openai params to only provide if set

---

Message subclass with custom format method

```python
from typing import Any
from magentic import chatprompt
from magentic.chat_model.message import Message


class UppercaseMessage(Message[str]):
    def format(self, **kwargs: Any) -> "UppercaseMessage":
        upper_kwargs = {k: str(v).upper() for k, v in kwargs.items()}
        return UppercaseMessage(self.content.format(**upper_kwargs))


@chatprompt(
    UppercaseMessage("hello {x}"),
)
def say_hello(x: str) -> str:
    ...


say_hello.format("world")
# [UppercaseMessage('hello WORLD')]
```

---

Registering custom subclass openai message serialization

```python
from typing import Any

from magentic.chat_model.openai_chat_model import OpenaiMessageRole, message_to_openai_message
from magentic.chat_model.message import Message
from openai.types.chat import ChatCompletionMessageParam


class CustomMessage(Message[str]):
    def format(self, **kwargs: Any) -> "CustomMessage":
        return CustomMessage(self.content)


@message_to_openai_message.register
def _(message: CustomMessage) -> ChatCompletionMessageParam:
    return {"role": OpenaiMessageRole.USER.value, "content": message.content}


message_to_openai_message(CustomMessage("hello"))
# {'role': 'user', 'content': 'hello'}
```