### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,7 @@ repos:
     rev: "1.16.0"
     hooks:
       - id: blacken-docs
+        additional_dependencies:
+          # New versions move ... inline with def
+          # https://github.com/psf/black/releases/tag/24.1.0
+          - black<24.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
+    rev: v0.2.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
- Update pre-commit hooks
- Pin black version for blacken-docs to prevent `...` moved inline with `def`