### PR TITLE
Add docs and classes for formatting objects in prompts

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -1,0 +1,94 @@
+# Formatting
+
+## The `format` Method
+
+Functions created using magentic decorators expose a `format` method that accepts the same parameters as the function itself but returns the completed prompt that will be sent to the model. For `@prompt` this is a string, and for `@chatprompt` this is a list of `Message` objects. The `format` method can be used to test that the final prompt created by a magentic function is formatted as expected.
+
+```python
+from magentic import prompt
+
+
+@prompt("Write a short poem about {topic}.")
+def create_poem(topic: str) -> str:
+    ...
+
+
+create_poem.format("fruit")
+# 'Write a short poem about fruit.'
+```
+
+## Classes for Formatting
+
+By default, when a list is used in a prompt template string it is formatted using its Python representation.
+
+```python
+from magentic import prompt
+from magentic.formatting import BulletedList
+
+
+@prompt("Continue the list:\n{items}")
+def get_next_items(items: list[str]) -> list[str]:
+    ...
+
+
+items = ["apple", "banana", "cherry"]
+print(get_next_items.format(items=items))
+# Continue the list:
+# ['apple', 'banana', 'cherry']
+```
+
+However, the LLM might respond better to a prompt in which the list is formatted more clearly or the items are numbered. The `BulletedList`, `NumberedList`, `BulletedDict` and `NumberedDict` classes are provided to enable this.
+
+For example, to modify the above prompt to contain a numbered list of the items, the `NumberedList` class can be used. This behaves exactly like a regular Python `list` except for how it appears when inserted into a formatted string. This class can also be used as the type annotation for `items` parameter to ensure that this prompt always contains a numbered list.
+
+```python hl_lines="6 10"
+from magentic import prompt
+from magentic.formatting import NumberedList
+
+
+@prompt("Continue the list:\n{items}")
+def get_next_items(items: NumberedList[str]) -> list[str]:
+    ...
+
+
+items = NumberedList(["apple", "banana", "cherry"])
+print(get_next_items.format(items=items))
+# Continue the list:
+# 1. apple
+# 2. banana
+# 3. cherry
+```
+
+## Custom Formatting
+
+When objects are inserted into formatted strings in Python, the `__format__` method is called. By defining or modifying this method you can control how an object is converted to a string in the prompt. If you own the class you can modify the `__format__` method directly. Otherwise for third-party classes you will need to create a subcless.
+
+Here's an example of how to represent a dictionary as a bulleted list.
+
+```python
+from typing import TypeVar
+
+from magentic import prompt
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class BulletedDict(dict[K, V]):
+    def __format__(self, format_spec: str) -> str:
+        # Here, you could use 'format_spec' to customize the formatting further if needed
+        return "\n".join(f"- {key}: {value}" for key, value in self.items())
+
+
+@prompt("Identify the odd one out:\n{items}")
+def find_odd_one_out(items: BulletedDict[str, str]) -> str:
+    ...
+
+
+items = BulletedDict({"sky": "blue", "grass": "green", "sun": "purple"})
+print(find_odd_one_out.format(items))
+# Identify the odd one out:
+# - sky: blue
+# - grass: green
+# - sun: purple
+```

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -2,7 +2,7 @@
 
 ## The `format` Method
 
-Functions created using magentic decorators expose a `format` method that accepts the same parameters as the function itself but returns the completed prompt that will be sent to the model. For `@prompt` this is a string, and for `@chatprompt` this is a list of `Message` objects. The `format` method can be used to test that the final prompt created by a magentic function is formatted as expected.
+Functions created using magentic decorators expose a `format` method that accepts the same parameters as the function itself but returns the completed prompt that will be sent to the model. For `@prompt` this method returns a string, and for `@chatprompt` it returns a list of `Message` objects. The `format` method can be used to test that the final prompt created by a magentic function is formatted as expected.
 
 ```python
 from magentic import prompt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
   - asyncio.md
   - streaming.md
   - vision.md
+  - formatting.md
   - configuration.md
   - type-checking.md
   - Examples:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,10 +76,10 @@ validation:
 nav:
   - Overview: index.md
   - chat-prompting.md
+  - formatting.md
   - asyncio.md
   - streaming.md
   - vision.md
-  - formatting.md
   - configuration.md
   - type-checking.md
   - Examples:

--- a/src/magentic/formatting.py
+++ b/src/magentic/formatting.py
@@ -1,0 +1,62 @@
+from collections import OrderedDict
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+class BulletedList(list[T]):
+    """A list of items that is formatted as a bulleted list.
+
+    When an instance of this class is formatted using the `format` function
+    or the `f-string` syntax, it will be formatted as a bulleted list.
+
+    Example:
+    --------
+    Create an instance of BulletedList and insert it into an f-string:
+
+        items = BulletedList(["foo", "bar", "baz"])
+        print(f"{items}")
+
+    This will output:
+
+        - foo
+        - bar
+        - baz
+    """
+
+    def __format__(self, format_spec: str) -> str:
+        return "\n".join(f"- {item}" for item in self)
+
+    def __repr__(self) -> str:
+        return f"BulletedList({super().__repr__()})"
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class BulletedDict(OrderedDict[K, V]):
+    """A dictionary that is formatted as a bulleted list.
+
+    When an instance of this class is formatted using the `format` function
+    or the `f-string` syntax, it will be formatted as a bulleted list.
+
+    Example
+    -------
+    Create an instance of BulletedDict and insert it into an f-string:
+
+        items = BulletedDict({"foo": 1, "bar": 2, "baz": 3})
+        print(f"{items}")
+
+    This will output:
+
+        - foo: 1
+        - bar: 2
+        - baz: 3
+    """
+
+    def __format__(self, format_spec: str) -> str:
+        return "\n".join(f"- {key}: {value}" for key, value in self.items())
+
+    def __repr__(self) -> str:
+        return f"BulletedDict({super().__repr__()})"

--- a/src/magentic/formatting.py
+++ b/src/magentic/formatting.py
@@ -31,6 +31,33 @@ class BulletedList(list[T]):
         return f"BulletedList({super().__repr__()})"
 
 
+class NumberedList(list[T]):
+    """A list of items that is formatted as a numbered list.
+
+    When an instance of this class is formatted using the `format` function
+    or the `f-string` syntax, it will be formatted as a numbered list.
+
+    Example:
+    --------
+    Create an instance of NumberedList and insert it into an f-string:
+
+        items = NumberedList(["foo", "bar", "baz"])
+        print(f"{items}")
+
+    This will output:
+
+        1. foo
+        2. bar
+        3. baz
+    """
+
+    def __format__(self, format_spec: str) -> str:
+        return "\n".join(f"{i}. {item}" for i, item in enumerate(self, 1))
+
+    def __repr__(self) -> str:
+        return f"NumberedList({super().__repr__()})"
+
+
 K = TypeVar("K")
 V = TypeVar("V")
 
@@ -60,3 +87,32 @@ class BulletedDict(OrderedDict[K, V]):
 
     def __repr__(self) -> str:
         return f"BulletedDict({super().__repr__()})"
+
+
+class NumberedDict(OrderedDict[K, V]):
+    """A dictionary that is formatted as a numbered list.
+
+    When an instance of this class is formatted using the `format` function
+    or the `f-string` syntax, it will be formatted as a numbered list.
+
+    Example
+    -------
+    Create an instance of NumberedDict and insert it into an f-string:
+
+        items = NumberedDict({"foo": 1, "bar": 2, "baz": 3})
+        print(f"{items}")
+
+    This will output:
+
+        1. foo: 1
+        2. bar: 2
+        3. baz: 3
+    """
+
+    def __format__(self, format_spec: str) -> str:
+        return "\n".join(
+            f"{i}. {key}: {value}" for i, (key, value) in enumerate(self.items(), 1)
+        )
+
+    def __repr__(self) -> str:
+        return f"NumberedDict({super().__repr__()})"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,4 +1,4 @@
-from magentic.formatting import BulletedDict, BulletedList
+from magentic.formatting import BulletedDict, BulletedList, NumberedDict, NumberedList
 
 
 def test_bulleted_list():
@@ -6,6 +6,16 @@ def test_bulleted_list():
     assert f"{items}" == "- foo\n- bar\n- baz"
 
 
+def test_numbered_list():
+    items = NumberedList(["foo", "bar", "baz"])
+    assert f"{items}" == "1. foo\n2. bar\n3. baz"
+
+
 def test_bulleted_dict():
     items = BulletedDict({"foo": 1, "bar": 2, "baz": 3})
     assert f"{items}" == "- foo: 1\n- bar: 2\n- baz: 3"
+
+
+def test_numbered_dict():
+    items = NumberedDict({"foo": 1, "bar": 2, "baz": 3})
+    assert f"{items}" == "1. foo: 1\n2. bar: 2\n3. baz: 3"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,11 @@
+from magentic.formatting import BulletedDict, BulletedList
+
+
+def test_bulleted_list():
+    items = BulletedList(["foo", "bar", "baz"])
+    assert f"{items}" == "- foo\n- bar\n- baz"
+
+
+def test_bulleted_dict():
+    items = BulletedDict({"foo": 1, "bar": 2, "baz": 3})
+    assert f"{items}" == "- foo: 1\n- bar: 2\n- baz: 3"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,21 +1,27 @@
+from typing_extensions import assert_type
+
 from magentic.formatting import BulletedDict, BulletedList, NumberedDict, NumberedList
 
 
 def test_bulleted_list():
     items = BulletedList(["foo", "bar", "baz"])
+    assert_type(items, BulletedList[str])
     assert f"{items}" == "- foo\n- bar\n- baz"
 
 
 def test_numbered_list():
     items = NumberedList(["foo", "bar", "baz"])
+    assert_type(items, NumberedList[str])
     assert f"{items}" == "1. foo\n2. bar\n3. baz"
 
 
 def test_bulleted_dict():
     items = BulletedDict({"foo": 1, "bar": 2, "baz": 3})
+    assert_type(items, BulletedDict[str, int])
     assert f"{items}" == "- foo: 1\n- bar: 2\n- baz: 3"
 
 
 def test_numbered_dict():
     items = NumberedDict({"foo": 1, "bar": 2, "baz": 3})
+    assert_type(items, NumberedDict[str, int])
     assert f"{items}" == "1. foo: 1\n2. bar: 2\n3. baz: 3"

--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -24,6 +24,18 @@ def test_promptfunction_format():
     assert func.format("arg") == "Test arg."
 
 
+def test_promptfunction_format_custom_type():
+    class CustomType:
+        def __format__(self, __format_spec: str) -> str:
+            return "custom"
+
+    @prompt("Test {param}.")
+    def func(param: CustomType) -> str:
+        ...
+
+    assert func.format(CustomType()) == "Test custom."
+
+
 def test_promptfunction_call():
     mock_model = Mock()
     mock_model.complete.return_value = AssistantMessage(content="Hello!")


### PR DESCRIPTION
- Add `BulletedList`, `NumberedList`, `BulletedDict` and `NumberedDict` classes for formatting.
- Add "formatting" docs page about these classes and how to customize formatting in prompts.