### PR TITLE
Docs: Fix bytes vision example

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -76,8 +76,11 @@ IMAGE_URL_WOODEN_BOARDWALK = "https://upload.wikimedia.org/wikipedia/commons/thu
 
 def url_to_bytes(url: str) -> bytes:
     """Get the content of a URL as bytes."""
-    return requests.get(url).content
-
+    
+    # A custom user-agent is necessary to comply with Wikimedia user-agent policy
+    # https://meta.wikimedia.org/wiki/User-Agent_policy
+    headers = {'User-Agent': 'MagenticExampleBot (https://magentic.dev/)'}
+    return requests.get(url, headers=headers).content
 
 @chatprompt(
     UserMessage("Describe the following image in one sentence."),


### PR DESCRIPTION
This is necessary because of [Wikimedia's user-agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy) that results in a 403 being returned rather than an image if a user agent isn't specified. This, in-turn,  causes the example to fail if it is copy-pasted with a `BadRequestError` since the response from Wikimedia is not an image.

Feel free to tweak the comment / User-agent. 