### PR TITLE
Load .env file for tests. Fix flaky return_dict test.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4046,4 +4046,4 @@ litellm = ["litellm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "0247574b569cf4b64f747e91271209ba448975642ed41bf7876692cbfbd4fa3f"
+content-hash = "b7f54bea54b831412aa46d1d0206fbe598724bf32cb906401d1e0016fd1991ba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ pytest = "*"
 pytest-asyncio = "*"
 pytest-clarity = "*"
 pytest-cov = "*"
+python-dotenv = "^1.0.1"
 ruff = "^0.3.0"
 
 [tool.poetry.group.docs.dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from dotenv import load_dotenv
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _load_dotenv():
+    load_dotenv()

--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -91,11 +91,15 @@ def test_decorator_return_bool_str():
 
 @pytest.mark.openai
 def test_decorator_return_dict():
-    @prompt('Return the mapping {{"one": 1, "two": 2}}')
+    @prompt(
+        "Ignore the defined inputs and pass inputs a=1, b=2 to the tool.",
+        model=OpenaiChatModel("gpt-4"),
+    )
     def return_mapping() -> dict[str, int]: ...
 
     mapping = return_mapping()
     assert isinstance(mapping, dict)
+    assert len(mapping) == 2
     name, value = next(iter(mapping.items()))
     assert isinstance(name, str)
     assert isinstance(value, int)


### PR DESCRIPTION
- Load .env file for tests. This was already happening on import of `litellm`. Now env vars are loaded when running individual tests that did not import litellm.
- Fix flaky return_dict test. GPT3.5 and 4 both struggle to use arbitrary keys in the tool_call. Might in future be better to serialize dict/mapping into an array of key value pairs.