### PR TITLE
Remove unneeded wrapper functions for openai and litellm completion

### DIFF
--- a/src/magentic/chat.py
+++ b/src/magentic/chat.py
@@ -58,7 +58,7 @@ class Chat:
             messages=[UserMessage(content=prompt.format(*args, **kwargs))],
             functions=prompt.functions,
             output_types=prompt.return_types,
-            model=prompt.model,
+            model=prompt._model,  # Keep `None` value if unset
         )
 
     @property
@@ -79,7 +79,7 @@ class Chat:
             messages=[*self._messages, message],
             functions=self._functions,
             output_types=self._output_types,
-            model=self.model,
+            model=self._model,  # Keep `None` value if unset
         )
 
     def add_user_message(self: Self, content: str) -> Self:

--- a/src/magentic/chat_model/litellm_chat_model.py
+++ b/src/magentic/chat_model/litellm_chat_model.py
@@ -20,6 +20,7 @@ from magentic.chat_model.message import (
     Message,
 )
 from magentic.chat_model.openai_chat_model import (
+    STR_OR_FUNCTIONCALL_TYPE,
     AsyncFunctionToolSchema,
     FunctionToolSchema,
     aparse_streamed_tool_calls,
@@ -28,7 +29,6 @@ from magentic.chat_model.openai_chat_model import (
 )
 from magentic.function_call import (
     AsyncParallelFunctionCall,
-    FunctionCall,
     ParallelFunctionCall,
 )
 from magentic.streaming import (
@@ -187,9 +187,7 @@ class LitellmChatModel(ChatModel):
         function_schemas = [FunctionCallFunctionSchema(f) for f in functions or []] + [
             function_schema_for_type(type_)
             for type_ in output_types
-            if not is_origin_subclass(
-                type_, (str, StreamedStr, FunctionCall, ParallelFunctionCall)
-            )
+            if not is_origin_subclass(type_, STR_OR_FUNCTIONCALL_TYPE)
         ]
         tool_schemas = [FunctionToolSchema(schema) for schema in function_schemas]
 
@@ -296,7 +294,7 @@ class LitellmChatModel(ChatModel):
         function_schemas = [FunctionCallFunctionSchema(f) for f in functions or []] + [
             async_function_schema_for_type(type_)
             for type_ in output_types
-            if not is_origin_subclass(type_, (str, AsyncStreamedStr, FunctionCall))
+            if not is_origin_subclass(type_, STR_OR_FUNCTIONCALL_TYPE)
         ]
         tool_schemas = [AsyncFunctionToolSchema(schema) for schema in function_schemas]
 

--- a/src/magentic/chat_model/litellm_chat_model.py
+++ b/src/magentic/chat_model/litellm_chat_model.py
@@ -1,12 +1,7 @@
-from collections.abc import AsyncIterator, Callable, Iterable
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator
 from itertools import chain
-from typing import Any, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
-from openai.types.chat import (
-    ChatCompletionMessageParam,
-    ChatCompletionToolChoiceOptionParam,
-    ChatCompletionToolParam,
-)
 from pydantic import ValidationError
 
 from magentic.chat_model.base import ChatModel, StructuredOutputError
@@ -24,6 +19,7 @@ from magentic.chat_model.openai_chat_model import (
     AsyncFunctionToolSchema,
     FunctionToolSchema,
     aparse_streamed_tool_calls,
+    discard_none_arguments,
     message_to_openai_message,
     parse_streamed_tool_calls,
 )
@@ -41,80 +37,12 @@ from magentic.typing import is_any_origin_subclass, is_origin_subclass
 
 try:
     import litellm
-    from litellm.utils import CustomStreamWrapper, ModelResponse
+
+    if TYPE_CHECKING:
+        from litellm.utils import ModelResponse
 except ImportError as error:
     msg = "To use LitellmChatModel you must install the `litellm` package using `pip install magentic[litellm]`."
     raise ImportError(msg) from error
-
-
-def litellm_completion(
-    model: str,
-    messages: list[ChatCompletionMessageParam],
-    api_base: str | None = None,
-    max_tokens: int | None = None,
-    stop: list[str] | None = None,
-    temperature: float | None = None,
-    tools: list[ChatCompletionToolParam] | None = None,
-    tool_choice: ChatCompletionToolChoiceOptionParam | None = None,
-) -> CustomStreamWrapper:
-    """Type-annotated version of `litellm.completion`."""
-    # `litellm.completion` doesn't accept `None`
-    # so only pass args with values
-    kwargs: dict[str, Any] = {}
-    if api_base is not None:
-        kwargs["api_base"] = api_base
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
-    if temperature is not None:
-        kwargs["temperature"] = temperature
-    if tools:
-        kwargs["tools"] = tools
-    if tool_choice:
-        kwargs["tool_choice"] = tool_choice
-
-    response: CustomStreamWrapper = litellm.completion(  # type: ignore[no-untyped-call,unused-ignore]
-        model=model,
-        messages=messages,
-        stop=stop,
-        stream=True,
-        **kwargs,
-    )
-    return response
-
-
-async def litellm_acompletion(
-    model: str,
-    messages: list[ChatCompletionMessageParam],
-    api_base: str | None = None,
-    max_tokens: int | None = None,
-    stop: list[str] | None = None,
-    temperature: float | None = None,
-    tools: list[ChatCompletionToolParam] | None = None,
-    tool_choice: ChatCompletionToolChoiceOptionParam | None = None,
-) -> AsyncIterator[ModelResponse]:
-    """Type-annotated version of `litellm.acompletion`."""
-    # `litellm.acompletion` doesn't accept `None`
-    # so only pass args with values
-    kwargs: dict[str, Any] = {}
-    if api_base is not None:
-        kwargs["api_base"] = api_base
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
-    if temperature is not None:
-        kwargs["temperature"] = temperature
-    if tools:
-        kwargs["tools"] = tools
-    if tool_choice:
-        kwargs["tool_choice"] = tool_choice
-
-    response: AsyncIterator[ModelResponse] = await litellm.acompletion(  # type: ignore[no-untyped-call,unused-ignore]
-        model=model,
-        messages=messages,
-        stop=stop,
-        stream=True,
-        **kwargs,
-    )
-    return response
 
 
 R = TypeVar("R")
@@ -195,12 +123,13 @@ class LitellmChatModel(ChatModel):
         streamed_str_in_output_types = is_any_origin_subclass(output_types, StreamedStr)
         allow_string_output = str_in_output_types or streamed_str_in_output_types
 
-        response = litellm_completion(
+        response: Iterator[ModelResponse] = discard_none_arguments(litellm.completion)(
             model=self.model,
             messages=[message_to_openai_message(m) for m in messages],
             api_base=self.api_base,
             max_tokens=self.max_tokens,
             stop=stop,
+            stream=True,
             temperature=self.temperature,
             tools=[schema.to_dict() for schema in tool_schemas],
             tool_choice=(
@@ -304,12 +233,15 @@ class LitellmChatModel(ChatModel):
         )
         allow_string_output = str_in_output_types or async_streamed_str_in_output_types
 
-        response = await litellm_acompletion(
+        response: AsyncIterator[ModelResponse] = await discard_none_arguments(
+            litellm.acompletion
+        )(
             model=self.model,
             messages=[message_to_openai_message(m) for m in messages],
             api_base=self.api_base,
             max_tokens=self.max_tokens,
             stop=stop,
+            stream=True,
             temperature=self.temperature,
             tools=[schema.to_dict() for schema in tool_schemas],
             tool_choice=(

--- a/src/magentic/chat_model/litellm_chat_model.py
+++ b/src/magentic/chat_model/litellm_chat_model.py
@@ -131,7 +131,7 @@ class LitellmChatModel(ChatModel):
             stop=stop,
             stream=True,
             temperature=self.temperature,
-            tools=[schema.to_dict() for schema in tool_schemas],
+            tools=[schema.to_dict() for schema in tool_schemas] or None,
             tool_choice=(
                 tool_schemas[0].as_tool_choice()
                 if len(tool_schemas) == 1 and not allow_string_output
@@ -243,7 +243,7 @@ class LitellmChatModel(ChatModel):
             stop=stop,
             stream=True,
             temperature=self.temperature,
-            tools=[schema.to_dict() for schema in tool_schemas],
+            tools=[schema.to_dict() for schema in tool_schemas] or None,
             tool_choice=(
                 tool_schemas[0].as_tool_choice()
                 if len(tool_schemas) == 1 and not allow_string_output

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -435,7 +435,7 @@ class OpenaiChatModel(ChatModel):
             stop=stop,
             stream=True,
             temperature=self.temperature,
-            tools=[schema.to_dict() for schema in tool_schemas],
+            tools=[schema.to_dict() for schema in tool_schemas] or openai.NOT_GIVEN,
             tool_choice=(
                 tool_schemas[0].as_tool_choice()
                 if len(tool_schemas) == 1 and not allow_string_output
@@ -549,7 +549,7 @@ class OpenaiChatModel(ChatModel):
             stop=stop,
             stream=True,
             temperature=self.temperature,
-            tools=[schema.to_dict() for schema in tool_schemas],
+            tools=[schema.to_dict() for schema in tool_schemas] or openai.NOT_GIVEN,
             tool_choice=(
                 tool_schemas[0].as_tool_choice()
                 if len(tool_schemas) == 1 and not allow_string_output

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -317,8 +317,12 @@ def openai_chatcompletion_create(
     kwargs: dict[str, Any] = {}
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
+    if seed is not None:
+        kwargs["seed"] = seed
     if stop is not None:
         kwargs["stop"] = stop
+    if temperature is not None:
+        kwargs["temperature"] = temperature
     if tools:
         kwargs["tools"] = tools
     if tool_choice:
@@ -327,9 +331,7 @@ def openai_chatcompletion_create(
     response: Iterator[ChatCompletionChunk] = client.chat.completions.create(
         model=model,
         messages=messages,
-        seed=seed,
         stream=True,
-        temperature=temperature,
         **kwargs,
     )
     return response
@@ -364,8 +366,12 @@ async def openai_chatcompletion_acreate(
     kwargs: dict[str, Any] = {}
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
+    if seed is not None:
+        kwargs["seed"] = seed
     if stop is not None:
         kwargs["stop"] = stop
+    if temperature is not None:
+        kwargs["temperature"] = temperature
     if tools:
         kwargs["tools"] = tools
     if tool_choice:
@@ -374,8 +380,6 @@ async def openai_chatcompletion_acreate(
     response: AsyncIterator[ChatCompletionChunk] = await client.chat.completions.create(
         model=model,
         messages=messages,
-        seed=seed,
-        temperature=temperature,
         stream=True,
         **kwargs,
     )

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -302,6 +302,16 @@ def discard_none_arguments(func: Callable[P, R]) -> Callable[P, R]:
     return wrapped
 
 
+STR_OR_FUNCTIONCALL_TYPE = (
+    str,
+    StreamedStr,
+    AsyncStreamedStr,
+    FunctionCall,
+    ParallelFunctionCall,
+    AsyncParallelFunctionCall,
+)
+
+
 class OpenaiChatModel(ChatModel):
     """An LLM chat model that uses the `openai` python package."""
 
@@ -405,9 +415,7 @@ class OpenaiChatModel(ChatModel):
         function_schemas = [FunctionCallFunctionSchema(f) for f in functions or []] + [
             function_schema_for_type(type_)
             for type_ in output_types
-            if not is_origin_subclass(
-                type_, (str, StreamedStr, FunctionCall, ParallelFunctionCall)
-            )
+            if not is_origin_subclass(type_, STR_OR_FUNCTIONCALL_TYPE)
         ]
         tool_schemas = [FunctionToolSchema(schema) for schema in function_schemas]
 
@@ -519,7 +527,7 @@ class OpenaiChatModel(ChatModel):
         function_schemas = [FunctionCallFunctionSchema(f) for f in functions or []] + [
             async_function_schema_for_type(type_)
             for type_ in output_types
-            if not is_origin_subclass(type_, (str, AsyncStreamedStr, FunctionCall))
+            if not is_origin_subclass(type_, STR_OR_FUNCTIONCALL_TYPE)
         ]
         tool_schemas = [AsyncFunctionToolSchema(schema) for schema in function_schemas]
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -510,13 +510,14 @@ class OpenaiChatModel(ChatModel):
         if len(first_chunk.choices) == 0:
             first_chunk = next(response)
         if (
-            first_chunk.choices[0].delta.content is None
-            and first_chunk.choices[0].delta.tool_calls is None
+            # Mistral tool call first chunk has content ""
+            not first_chunk.choices[0].delta.content
+            and not first_chunk.choices[0].delta.tool_calls
         ):
             first_chunk = next(response)
         response = chain([first_chunk], response)
 
-        if first_chunk.choices[0].delta.content is not None:
+        if first_chunk.choices[0].delta.content:
             if not allow_string_output:
                 msg = (
                     "String was returned by model but not expected. You may need to update"
@@ -532,7 +533,7 @@ class OpenaiChatModel(ChatModel):
                 return AssistantMessage(streamed_str)  # type: ignore[return-value]
             return AssistantMessage(str(streamed_str))
 
-        if first_chunk.choices[0].delta.tool_calls is not None:
+        if first_chunk.choices[0].delta.tool_calls:
             try:
                 if is_any_origin_subclass(output_types, ParallelFunctionCall):
                     content = ParallelFunctionCall(
@@ -623,13 +624,14 @@ class OpenaiChatModel(ChatModel):
         if len(first_chunk.choices) == 0:
             first_chunk = await anext(response)
         if (
-            first_chunk.choices[0].delta.content is None
-            and first_chunk.choices[0].delta.tool_calls is None
+            # Mistral tool call first chunk has content ""
+            not first_chunk.choices[0].delta.content
+            and not first_chunk.choices[0].delta.tool_calls
         ):
             first_chunk = await anext(response)
         response = achain(async_iter([first_chunk]), response)
 
-        if first_chunk.choices[0].delta.content is not None:
+        if first_chunk.choices[0].delta.content:
             if not allow_string_output:
                 msg = (
                     "String was returned by model but not expected. You may need to update"
@@ -645,7 +647,7 @@ class OpenaiChatModel(ChatModel):
                 return AssistantMessage(async_streamed_str)  # type: ignore[return-value]
             return AssistantMessage(await async_streamed_str.to_string())
 
-        if first_chunk.choices[0].delta.tool_calls is not None:
+        if first_chunk.choices[0].delta.tool_calls:
             try:
                 if is_any_origin_subclass(output_types, AsyncParallelFunctionCall):
                     content = AsyncParallelFunctionCall(

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -292,6 +292,8 @@ R = TypeVar("R")
 
 
 def discard_none_arguments(func: Callable[P, R]) -> Callable[P, R]:
+    """Decorator to discard function arguments with value `None`"""
+
     @wraps(func)
     def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
         non_none_kwargs = {

--- a/tests/chat_model/test_openai_chat_model.py
+++ b/tests/chat_model/test_openai_chat_model.py
@@ -118,9 +118,8 @@ def test_openai_chat_model_api_key(monkeypatch):
     openai_api_key = os.environ["OPENAI_API_KEY"]
     monkeypatch.delenv("OPENAI_API_KEY")
 
-    chat_model = OpenaiChatModel("gpt-3.5-turbo")
     with pytest.raises(openai.OpenAIError):
-        chat_model.complete(messages=[UserMessage("Say hello!")])
+        chat_model = OpenaiChatModel("gpt-3.5-turbo")
 
     chat_model = OpenaiChatModel("gpt-3.5-turbo", api_key=openai_api_key)
     message = chat_model.complete(messages=[UserMessage("Say hello!")])

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -12,7 +12,7 @@ def test_backend_openai_chat_model(monkeypatch):
     monkeypatch.setenv("MAGENTIC_BACKEND", "openai")
     monkeypatch.setenv("MAGENTIC_OPENAI_MODEL", "gpt-4")
     monkeypatch.setenv("MAGENTIC_OPENAI_API_KEY", "sk-1234567890")
-    monkeypatch.setenv("MAGENTIC_OPENAI_API_TYPE", "azure")
+    monkeypatch.setenv("MAGENTIC_OPENAI_API_TYPE", "openai")
     monkeypatch.setenv("MAGENTIC_OPENAI_BASE_URL", "http://localhost:8080")
     monkeypatch.setenv("MAGENTIC_OPENAI_MAX_TOKENS", "1024")
     monkeypatch.setenv("MAGENTIC_OPENAI_SEED", "42")
@@ -21,7 +21,7 @@ def test_backend_openai_chat_model(monkeypatch):
     assert isinstance(chat_model, OpenaiChatModel)
     assert chat_model.model == "gpt-4"
     assert chat_model.api_key == "sk-1234567890"
-    assert chat_model.api_type == "azure"
+    assert chat_model.api_type == "openai"
     assert chat_model.base_url == "http://localhost:8080"
     assert chat_model.max_tokens == 1024
     assert chat_model.seed == 42

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -55,13 +55,15 @@ def test_openai_chat_model_completion():
     # TODO: test for num_tokens here
 
 
-def test_chat_model_context():
+def test_chat_model_context(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
     chat_model = OpenaiChatModel("gpt-4")
     with chat_model:
         assert get_chat_model() is chat_model
 
 
-def test_chat_model_context_within_context():
+def test_chat_model_context_within_context(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
     with OpenaiChatModel("gpt-4"):
         assert get_chat_model().model == "gpt-4"  # type: ignore[attr-defined]
 

--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -282,7 +282,9 @@ async def test_decorator_return_async_parallel_function_call():
     assert len(func_result) == 2
 
 
-def test_decorator_with_context_manager():
+def test_decorator_with_context_manager(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
     @prompt("Say hello")
     def say_hello() -> str: ...
 


### PR DESCRIPTION
- Remove unneeded wrapper functions for openai and litellm completion
- Use new `discard_none_arguments` to remove None args
- Create `STR_OR_FUNCTIONCALL_TYPE` to have single source for these
- Include fixes for (mostly) working with Mistral from PR #164 
- Fix `Chat` to maintain unset `model` attribute through method calls