### PR TITLE
Set default LLM to gpt-4-turbo. Update vision docs.

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,47 +1,58 @@
 # Vision
 
-GPT-4 Vision can be used with magentic by using the `UserImageMessage` message type. This allows the LLM to accept images as input. Currently this is only supported with the OpenAI backend (`OpenaiChatModel` with `"gpt-4-vision-preview"`).
+GPT-4 Vision can be used with magentic by using the `UserImageMessage` message type. This allows the LLM to accept images as input. Currently this is only supported with the OpenAI backend (`OpenaiChatModel`).
 
 !!! note "Return types"
 
-    GPT-4 Vision currently does not support function-calling/tools so functions using `@chatprompt` can only return `str`, `StreamedStr`, or `AsyncStreamedStr`.
+    `gpt-4-vision-preview` does not support function-calling/tools so only `str`, `StreamedStr`, and `AsyncStreamedStr` work as return types.
 
 !!! tip "`max_tokens`"
 
-    By default `max_tokens` has a low value, so you will likely need to increase it.
+    By default, `gpt-4-vision-preview` has a low value for `max_tokens` so you will likely need to increase it.
 
 For more information visit the [OpenAI Vision API documentation](https://platform.openai.com/docs/guides/vision).
 
 ## UserImageMessage
 
-The `UserImageMessage` can be used with `@chatprompt` alongside other messages. The LLM must be set to OpenAI's GPT4 Vision model `OpenaiChatModel("gpt-4-vision-preview")`. This can be done by passing the `model` parameter to `@chatprompt`, or through the other methods of [configuration](configuration.md).
+The `UserImageMessage` can be used in `@chatprompt` alongside other messages. The LLM must be set to an OpenAI model that supports vision, currently `gpt-4-vision-preview` and `gpt-4-turbo` (the default `ChatModel`). This can be done by passing the `model` parameter to `@chatprompt`, or through the other methods of [configuration](configuration.md).
 
 ```python
-from magentic import chatprompt, OpenaiChatModel, UserMessage
+from pydantic import BaseModel, Field
+
+from magentic import chatprompt, UserMessage
 from magentic.vision import UserImageMessage
 
 
 IMAGE_URL_WOODEN_BOARDWALK = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
 
 
+class ImageDetails(BaseModel):
+    description: str = Field(description="A brief description of the image.")
+    name: str = Field(description="A short name.")
+
+
 @chatprompt(
     UserMessage("Describe the following image in one sentence."),
     UserImageMessage(IMAGE_URL_WOODEN_BOARDWALK),
-    model=OpenaiChatModel("gpt-4-vision-preview", max_tokens=2000),
 )
-def describe_image() -> str: ...
+def describe_image() -> ImageDetails: ...
 
 
-describe_image()
-# 'A wooden boardwalk meanders through a lush green meadow under a blue sky with wispy clouds.'
+image_details = describe_image()
+print(image_details.name)
+# 'Wooden Boardwalk in Green Wetland'
+print(image_details.description)
+# 'A serene wooden boardwalk meanders through a lush green wetland under a blue sky dotted with clouds.'
 ```
+
+For more info on the `@chatprompt` decorator, see [Chat Prompting](chat-prompting.md).
 
 ## Placeholder
 
-To provide the image as a function parameter, use `Placeholder`. This substitutes a function argument into the message when the function is called.
+In the previous example, the image url was tied to the function. To provide the image as a function parameter, use `Placeholder`. This substitutes a function argument into the message when the function is called.
 
 ```python hl_lines="10"
-from magentic import chatprompt, OpenaiChatModel, Placeholder, UserMessage
+from magentic import chatprompt, Placeholder, UserMessage
 from magentic.vision import UserImageMessage
 
 
@@ -51,7 +62,6 @@ IMAGE_URL_WOODEN_BOARDWALK = "https://upload.wikimedia.org/wikipedia/commons/thu
 @chatprompt(
     UserMessage("Describe the following image in one sentence."),
     UserImageMessage(Placeholder(str, "image_url")),
-    model=OpenaiChatModel("gpt-4-vision-preview", max_tokens=2000),
 )
 def describe_image(image_url: str) -> str: ...
 
@@ -67,7 +77,7 @@ describe_image(IMAGE_URL_WOODEN_BOARDWALK)
 ```python
 import requests
 
-from magentic import chatprompt, OpenaiChatModel, Placeholder, UserMessage
+from magentic import chatprompt, Placeholder, UserMessage
 from magentic.vision import UserImageMessage
 
 
@@ -76,16 +86,16 @@ IMAGE_URL_WOODEN_BOARDWALK = "https://upload.wikimedia.org/wikipedia/commons/thu
 
 def url_to_bytes(url: str) -> bytes:
     """Get the content of a URL as bytes."""
-    
+
     # A custom user-agent is necessary to comply with Wikimedia user-agent policy
     # https://meta.wikimedia.org/wiki/User-Agent_policy
-    headers = {'User-Agent': 'MagenticExampleBot (https://magentic.dev/)'}
-    return requests.get(url, headers=headers).content
+    headers = {"User-Agent": "MagenticExampleBot (https://magentic.dev/)"}
+    return requests.get(url, headers=headers, timeout=10).content
+
 
 @chatprompt(
     UserMessage("Describe the following image in one sentence."),
     UserImageMessage(Placeholder(bytes, "image_bytes")),
-    model=OpenaiChatModel("gpt-4-vision-preview", max_tokens=2000),
 )
 def describe_image(image_bytes: bytes) -> str: ...
 

--- a/src/magentic/chat_model/anthropic_chat_model.py
+++ b/src/magentic/chat_model/anthropic_chat_model.py
@@ -3,7 +3,6 @@ from collections.abc import AsyncIterator, Callable, Iterable, Iterator
 from enum import Enum
 from functools import singledispatch
 from typing import Any, Generic, TypeVar, cast, overload
-from uuid import uuid4
 
 from pydantic import ValidationError
 
@@ -27,6 +26,7 @@ from magentic.function_call import (
     AsyncParallelFunctionCall,
     FunctionCall,
     ParallelFunctionCall,
+    _create_unique_id,
 )
 from magentic.streaming import AsyncStreamedStr, StreamedStr, async_iter
 from magentic.typing import is_any_origin_subclass, is_origin_subclass
@@ -110,9 +110,9 @@ def _(message: AssistantMessage[Any]) -> ToolsBetaMessageParam:
         "role": AnthropicMessageRole.ASSISTANT.value,
         "content": [
             {
-                # Can be random because no result will be inserted back into the chat
                 "type": "tool_use",
-                "id": str(uuid4()),
+                # Can be random because no result will be inserted back into the chat
+                "id": _create_unique_id(),
                 "name": function_schema.name,
                 "input": json.loads(function_schema.serialize_args(message.content)),
             }

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -3,7 +3,6 @@ from enum import Enum
 from functools import singledispatch, wraps
 from itertools import chain, groupby, takewhile
 from typing import Any, Generic, Literal, ParamSpec, TypeVar, cast, overload
-from uuid import uuid4
 
 import openai
 from openai.types.chat import (
@@ -35,6 +34,7 @@ from magentic.function_call import (
     AsyncParallelFunctionCall,
     FunctionCall,
     ParallelFunctionCall,
+    _create_unique_id,
 )
 from magentic.streaming import (
     AsyncStreamedStr,
@@ -121,7 +121,7 @@ def _(message: AssistantMessage[Any]) -> ChatCompletionMessageParam:
         "tool_calls": [
             {
                 # Can be random because no result will be inserted back into the chat
-                "id": str(uuid4()),
+                "id": _create_unique_id(),
                 "type": "function",
                 "function": {
                     "name": function_schema.name,

--- a/src/magentic/function_call.py
+++ b/src/magentic/function_call.py
@@ -22,6 +22,11 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 
+def _create_unique_id() -> str:
+    # OpenAI has max length of 29 chars for function call IDs
+    return uuid4().hex[:29]
+
+
 class FunctionCall(Generic[T]):
     """A function with arguments supplied.
 
@@ -34,7 +39,7 @@ class FunctionCall(Generic[T]):
         self._kwargs = kwargs
 
         # Used to correlate function call with result on serialization
-        self._unique_id = str(uuid4())
+        self._unique_id = _create_unique_id()
 
     def __call__(self) -> T:
         return self._function(*self._args, **self._kwargs)

--- a/src/magentic/settings.py
+++ b/src/magentic/settings.py
@@ -21,12 +21,12 @@ class Settings(BaseSettings):
     anthropic_max_tokens: int = 1024
     anthropic_temperature: float | None = None
 
-    litellm_model: str = "gpt-3.5-turbo"
+    litellm_model: str = "gpt-4-turbo"
     litellm_api_base: str | None = None
     litellm_max_tokens: int | None = None
     litellm_temperature: float | None = None
 
-    openai_model: str = "gpt-3.5-turbo"
+    openai_model: str = "gpt-4-turbo"
     openai_api_key: str | None = None
     openai_api_type: Literal["openai", "azure"] = "openai"
     openai_base_url: str | None = None

--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -111,7 +111,7 @@ def test_decorator_return_pydantic_model():
         capital: str
         country: str
 
-    @prompt("What is the capital of {country}?")
+    @prompt("What is the capital of {country}? Follow the schema!")
     def get_capital(country: str) -> CapitalCity: ...
 
     output = get_capital("Ireland")


### PR DESCRIPTION
Set default LLM to gpt-4-turbo. Update vision docs.

Also fix
- tool id must be less than 29 chars for openai
- flake test `test_decorator_return_pydantic_model`

Now we can get structured outputs straight from vision 🎉 


```python
from pydantic import BaseModel, Field

from magentic import chatprompt, UserMessage
from magentic.vision import UserImageMessage


IMAGE_URL_WOODEN_BOARDWALK = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"


class ImageDetails(BaseModel):
    description: str = Field(description="A brief description of the image.")
    name: str = Field(description="A short name.")


@chatprompt(
    UserMessage("Describe the following image in one sentence."),
    UserImageMessage(IMAGE_URL_WOODEN_BOARDWALK),
)
def describe_image() -> ImageDetails: ...


image_details = describe_image()
print(image_details.name)
# 'Wooden Boardwalk in Green Wetland'
print(image_details.description)
# 'A serene wooden boardwalk meanders through a lush green wetland under a blue sky dotted with clouds.'
```