### PR TITLE
Include generated text in error message for "string not expected"

### DIFF
--- a/src/magentic/chat_model/anthropic_chat_model.py
+++ b/src/magentic/chat_model/anthropic_chat_model.py
@@ -343,7 +343,7 @@ class AnthropicChatModel(ChatModel):
             str_content = validate_str_content(
                 StreamedStr(last_content.text),
                 allow_string_output=allow_string_output,
-                streamed=True,
+                streamed=streamed_str_in_output_types,
             )
             return AssistantMessage(str_content)  # type: ignore[return-value]
 
@@ -437,7 +437,7 @@ class AnthropicChatModel(ChatModel):
             str_content = await avalidate_str_content(
                 AsyncStreamedStr(async_iter(last_content.text)),
                 allow_string_output=allow_string_output,
-                streamed=True,
+                streamed=async_streamed_str_in_output_types,
             )
             return AssistantMessage(str_content)  # type: ignore[return-value]
 

--- a/src/magentic/chat_model/anthropic_chat_model.py
+++ b/src/magentic/chat_model/anthropic_chat_model.py
@@ -7,7 +7,12 @@ from typing import Any, Generic, TypeVar, cast, overload
 from pydantic import ValidationError
 
 from magentic import FunctionResultMessage
-from magentic.chat_model.base import ChatModel, StructuredOutputError
+from magentic.chat_model.base import (
+    ChatModel,
+    StructuredOutputError,
+    avalidate_str_content,
+    validate_str_content,
+)
 from magentic.chat_model.function_schema import (
     AsyncFunctionSchema,
     BaseFunctionSchema,
@@ -335,17 +340,12 @@ class AnthropicChatModel(ChatModel):
         last_content = response.content[-1]
 
         if last_content.type == "text":
-            if not allow_string_output:
-                msg = (
-                    "String was returned by model but not expected. You may need to update"
-                    " your prompt to encourage the model to return a specific type."
-                    f" {response.model_dump_json()}"
-                )
-                raise StructuredOutputError(msg)
-            streamed_str = StreamedStr(last_content.text)
-            if streamed_str_in_output_types:
-                return AssistantMessage(streamed_str)  # type: ignore[return-value]
-            return AssistantMessage(str(streamed_str))
+            str_content = validate_str_content(
+                StreamedStr(last_content.text),
+                allow_string_output=allow_string_output,
+                streamed=True,
+            )
+            return AssistantMessage(str_content)  # type: ignore[return-value]
 
         if last_content.type == "tool_use":
             try:
@@ -434,17 +434,12 @@ class AnthropicChatModel(ChatModel):
         last_content = response.content[-1]
 
         if last_content.type == "text":
-            if not allow_string_output:
-                msg = (
-                    "String was returned by model but not expected. You may need to update"
-                    " your prompt to encourage the model to return a specific type."
-                    f" {response.model_dump_json()}"
-                )
-                raise StructuredOutputError(msg)
-            streamed_str = AsyncStreamedStr(async_iter(last_content.text))
-            if async_streamed_str_in_output_types:
-                return AssistantMessage(streamed_str)  # type: ignore[return-value]
-            return AssistantMessage(str(streamed_str))
+            str_content = await avalidate_str_content(
+                AsyncStreamedStr(async_iter(last_content.text)),
+                allow_string_output=allow_string_output,
+                streamed=True,
+            )
+            return AssistantMessage(str_content)  # type: ignore[return-value]
 
         if last_content.type == "tool_use":
             try:

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -8,6 +8,7 @@ from magentic.chat_model.message import (
     AssistantMessage,
     Message,
 )
+from magentic.streaming import AsyncStreamedStr, StreamedStr
 
 R = TypeVar("R")
 
@@ -18,6 +19,41 @@ _chat_model_context: ContextVar["ChatModel | None"] = ContextVar(
 
 class StructuredOutputError(Exception):
     """Raised when the LLM output could not be parsed."""
+
+
+_STRING_NOT_EXPECTED_ERROR_MESSAGE = (
+    "String was returned by model but not expected. You may need to update"
+    " your prompt to encourage the model to return a specific type."
+    " Model output: {model_output}"
+)
+
+
+def validate_str_content(
+    streamed_str: StreamedStr, *, allow_string_output: bool, streamed: bool
+) -> StreamedStr | str:
+    """Raise error if string output not expected. Otherwise return correct string type."""
+    if not allow_string_output:
+        msg = _STRING_NOT_EXPECTED_ERROR_MESSAGE.format(
+            model_output=streamed_str.truncate(50)
+        )
+        raise StructuredOutputError(msg)
+    if streamed:
+        return streamed_str
+    return str(streamed_str)
+
+
+async def avalidate_str_content(
+    async_streamed_str: AsyncStreamedStr, *, allow_string_output: bool, streamed: bool
+) -> AsyncStreamedStr | str:
+    """Async version of `validate_str_content`."""
+    if not allow_string_output:
+        msg = _STRING_NOT_EXPECTED_ERROR_MESSAGE.format(
+            model_output=await async_streamed_str.truncate(50)
+        )
+        raise StructuredOutputError(msg)
+    if streamed:
+        return async_streamed_str
+    return await async_streamed_str.to_string()
 
 
 class ChatModel(ABC):

--- a/src/magentic/chat_model/base.py
+++ b/src/magentic/chat_model/base.py
@@ -24,7 +24,7 @@ class StructuredOutputError(Exception):
 _STRING_NOT_EXPECTED_ERROR_MESSAGE = (
     "String was returned by model but not expected. You may need to update"
     " your prompt to encourage the model to return a specific type."
-    " Model output: {model_output}"
+    " Model output: {model_output!r}"
 )
 
 
@@ -34,7 +34,7 @@ def validate_str_content(
     """Raise error if string output not expected. Otherwise return correct string type."""
     if not allow_string_output:
         msg = _STRING_NOT_EXPECTED_ERROR_MESSAGE.format(
-            model_output=streamed_str.truncate(50)
+            model_output=streamed_str.truncate(100)
         )
         raise StructuredOutputError(msg)
     if streamed:
@@ -48,7 +48,7 @@ async def avalidate_str_content(
     """Async version of `validate_str_content`."""
     if not allow_string_output:
         msg = _STRING_NOT_EXPECTED_ERROR_MESSAGE.format(
-            model_output=await async_streamed_str.truncate(50)
+            model_output=await async_streamed_str.truncate(100)
         )
         raise StructuredOutputError(msg)
     if streamed:

--- a/src/magentic/streaming.py
+++ b/src/magentic/streaming.py
@@ -1,4 +1,5 @@
 import asyncio
+import textwrap
 from collections.abc import AsyncIterable, Iterable
 from dataclasses import dataclass
 from itertools import chain, dropwhile
@@ -199,6 +200,17 @@ class StreamedStr(Iterable[str]):
         """Convert the streamed string to a string."""
         return str(self)
 
+    def truncate(self, length: int) -> str:
+        """Truncate the streamed string to the specified length."""
+        chunks = []
+        current_length = 0
+        for chunk in self._chunks:
+            chunks.append(chunk)
+            current_length += len(chunk)
+            if current_length > length:
+                break
+        return textwrap.shorten("".join(chunks), width=length)
+
 
 class AsyncStreamedStr(AsyncIterable[str]):
     """Async version of `StreamedStr`."""
@@ -213,3 +225,14 @@ class AsyncStreamedStr(AsyncIterable[str]):
     async def to_string(self) -> str:
         """Convert the streamed string to a string."""
         return "".join([item async for item in self])
+
+    async def truncate(self, length: int) -> str:
+        """Truncate the streamed string to the specified length."""
+        chunks = []
+        current_length = 0
+        async for chunk in self._chunks:
+            chunks.append(chunk)
+            current_length += len(chunk)
+            if current_length > length:
+                break
+        return textwrap.shorten("".join(chunks), width=length)

--- a/tests/chat_model/test_litellm_chat_model.py
+++ b/tests/chat_model/test_litellm_chat_model.py
@@ -50,7 +50,9 @@ def test_litellm_chat_model_metadata(litellm_success_callback_calls):
     chat_model = LitellmChatModel("gpt-3.5-turbo", metadata={"foo": "bar"})
     assert chat_model.metadata == {"foo": "bar"}
     chat_model.complete(messages=[UserMessage("Say hello!")])
-    callback_call = litellm_success_callback_calls[0]
+    # There are multiple callback calls due to streaming
+    # Take the last one because the first is occasionally from another test
+    callback_call = litellm_success_callback_calls[-1]
     assert callback_call["kwargs"]["litellm_params"]["metadata"] == {"foo": "bar"}
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -124,6 +124,12 @@ def test_streamed_str_str():
     assert str(streamed_str) == "Hello World"
 
 
+def test_streamed_str_truncate():
+    streamed_str = StreamedStr(["First", " Second", " Third"])
+    assert streamed_str.truncate(length=12) == "First [...]"
+    assert streamed_str.truncate(length=99) == "First Second Third"
+
+
 @pytest.mark.asyncio
 async def test_async_streamed_str_iter():
     aiter_chunks = async_iter(["Hello", " World"])
@@ -137,3 +143,10 @@ async def test_async_streamed_str_iter():
 async def test_async_streamed_str_to_string():
     async_streamed_str = AsyncStreamedStr(async_iter(["Hello", " World"]))
     assert await async_streamed_str.to_string() == "Hello World"
+
+
+@pytest.mark.asyncio
+async def test_async_streamed_str_truncate():
+    async_streamed_str = AsyncStreamedStr(async_iter(["First", " Second", " Third"]))
+    assert await async_streamed_str.truncate(length=12) == "First [...]"
+    assert await async_streamed_str.truncate(length=99) == "First Second Third"


### PR DESCRIPTION
- Add truncate method to StreamedStr
- DRY up str return type creation + validation / error message

Error now looks like
```
StructuredOutputError: String was returned by model but not expected. You may need to update your prompt to encourage the model to return a specific type. Model output: '{ "name": "return_list_of_int", "arguments": { "properties": { "value": { "items": [1, 2, 3], [...]'
```