### PR TITLE
Skip validation for message serialization

### DIFF
--- a/src/magentic/chat_model/function_schema.py
+++ b/src/magentic/chat_model/function_schema.py
@@ -164,7 +164,7 @@ class AnyFunctionSchema(FunctionSchema[T], Generic[T]):
         return self._model.model_validate_json(args_json).value
 
     def serialize_args(self, value: T) -> str:
-        return self._model(value=value).model_dump_json()
+        return self._model.model_construct(value=value).model_dump_json()
 
 
 IterableT = TypeVar("IterableT", bound=Iterable[Any])
@@ -201,7 +201,7 @@ class IterableFunctionSchema(FunctionSchema[IterableT], Generic[IterableT]):
         return self._model.model_validate({"value": iter_items}).value
 
     def serialize_args(self, value: IterableT) -> str:
-        return self._model(value=value).model_dump_json()
+        return self._model.model_construct(value=value).model_dump_json()
 
 
 AsyncIterableT = TypeVar("AsyncIterableT", bound=AsyncIterable[Any])
@@ -246,7 +246,9 @@ class AsyncIterableFunctionSchema(
         raise NotImplementedError
 
     async def aserialize_args(self, value: AsyncIterableT) -> str:
-        return self._model(value=[chunk async for chunk in value]).model_dump_json()
+        return self._model.model_construct(
+            value=[chunk async for chunk in value]
+        ).model_dump_json()
 
 
 @register_function_schema(dict)
@@ -405,4 +407,6 @@ class FunctionCallFunctionSchema(FunctionSchema[FunctionCall[T]], Generic[T]):
         )
 
     def serialize_args(self, value: FunctionCall[T]) -> str:
-        return self._model(**value.arguments).model_dump_json(exclude_unset=True)
+        return self._model.model_construct(**value.arguments).model_dump_json(
+            exclude_unset=True
+        )

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -818,3 +818,21 @@ def test_function_call_function_schema_serialize_args(
 ):
     serialized_args = FunctionCallFunctionSchema(function).serialize_args(args)
     assert json.loads(serialized_args) == json.loads(expected_args_str)
+
+
+@pytest.mark.parametrize(
+    ("function", "expected_args_str", "args"),
+    [
+        (
+            plus,
+            '{"a": "non-int", "b": {"value": 5}}',
+            FunctionCall(plus, "non-int", IntModel(value=5)),  # type: ignore[arg-type]
+        ),
+    ],
+)
+def test_function_call_function_schema_serialize_invalid_args(
+    function, expected_args_str, args
+):
+    """Invalid function arguments should serialize so LLM errors can be resubmitted."""
+    serialized_args = FunctionCallFunctionSchema(function).serialize_args(args)
+    assert json.loads(serialized_args) == json.loads(expected_args_str)

--- a/tests/test_prompt_function.py
+++ b/tests/test_prompt_function.py
@@ -88,6 +88,7 @@ def test_decorator_return_bool_str():
     assert isinstance(output, bool)
 
 
+@pytest.mark.skip(reason="Flaky")  # TODO: Make dict function call more reliable
 @pytest.mark.openai
 def test_decorator_return_dict():
     @prompt(


### PR DESCRIPTION
Use `model_construct` to skip validation on serialization

Resolves #211 