### PR TITLE
Return usage stats on AssistantMessage

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2295,13 +2295,13 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.30.1"
+version = "1.30.3"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.7.1"
 files = [
-    {file = "openai-1.30.1-py3-none-any.whl", hash = "sha256:c9fb3c3545c118bbce8deb824397b9433a66d0d0ede6a96f7009c95b76de4a46"},
-    {file = "openai-1.30.1.tar.gz", hash = "sha256:4f85190e577cba0b066e1950b8eb9b11d25bc7ebcc43a86b326ce1bfa564ec74"},
+    {file = "openai-1.30.3-py3-none-any.whl", hash = "sha256:f88119c8a848998be533c71ab8aa832446fa72b7ddbc70917c3f5886dc132051"},
+    {file = "openai-1.30.3.tar.gz", hash = "sha256:8e1bcdca2b96fe3636ab522fa153d88efde1b702d12ec32f1c73e9553ff93f45"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2295,13 +2295,13 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.25.1"
+version = "1.30.1"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.7.1"
 files = [
-    {file = "openai-1.25.1-py3-none-any.whl", hash = "sha256:aa2f381f476f5fa4df8728a34a3e454c321caa064b7b68ab6e9daa1ed082dbf9"},
-    {file = "openai-1.25.1.tar.gz", hash = "sha256:f561ce86f4b4008eb6c78622d641e4b7e1ab8a8cdb15d2f0b2a49942d40d21a8"},
+    {file = "openai-1.30.1-py3-none-any.whl", hash = "sha256:c9fb3c3545c118bbce8deb824397b9433a66d0d0ede6a96f7009c95b76de4a46"},
+    {file = "openai-1.30.1.tar.gz", hash = "sha256:4f85190e577cba0b066e1950b8eb9b11d25bc7ebcc43a86b326ce1bfa564ec74"},
 ]
 
 [package.dependencies]
@@ -4093,4 +4093,4 @@ litellm = ["litellm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "b7a90da077d1b6b2af2778bf60299f547a32269ca874d245348d58dcec0fd1a9"
+content-hash = "b7f96b4fccd09710056169893a5cd34c8a5b36e1cada7375ab52054ce7b31678"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ python = ">=3.10,<4.0"
 anthropic = {version = ">=0.23.0", optional = true}
 filetype = "*"
 litellm = {version = ">=1.36.0", optional = true}
-openai = ">=1.24.0"
+openai = ">=1.26.0"
 pydantic = ">=2.0.0"
 pydantic-settings = ">=2.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "magentic"
-version = "0.24.0"
+version = "0.25.0a0"
 description = "Seamlessly integrate LLMs as Python functions"
 license = "MIT"
 authors = ["Jack Collins"]

--- a/src/magentic/chat_model/anthropic_chat_model.py
+++ b/src/magentic/chat_model/anthropic_chat_model.py
@@ -260,7 +260,7 @@ def _create_usage_ref(
     response: Iterable[ToolsBetaMessageStreamEvent],
 ) -> tuple[list[Usage], Iterator[ToolsBetaMessageStreamEvent]]:
     """Returns a pointer to a Usage object that is created at the end of the response."""
-    usage_ref = []
+    usage_ref: list[Usage] = []
 
     def generator(
         response: Iterable[ToolsBetaMessageStreamEvent],
@@ -288,7 +288,7 @@ def _create_usage_ref_async(
     response: AsyncIterable[ToolsBetaMessageStreamEvent],
 ) -> tuple[list[Usage], AsyncIterator[ToolsBetaMessageStreamEvent]]:
     """Async version of `_create_usage_ref`."""
-    usage_ref = []
+    usage_ref: list[Usage] = []
 
     async def agenerator(
         response: AsyncIterable[ToolsBetaMessageStreamEvent],

--- a/src/magentic/chat_model/anthropic_chat_model.py
+++ b/src/magentic/chat_model/anthropic_chat_model.py
@@ -28,7 +28,6 @@ from magentic.chat_model.message import (
     SystemMessage,
     Usage,
     UserMessage,
-    _assistant_message_with_usage,
 )
 from magentic.function_call import (
     AsyncParallelFunctionCall,
@@ -56,7 +55,6 @@ try:
         ToolUseBlock,
     )
     from anthropic.types.beta.tools.message_create_params import ToolChoice
-    from anthropic.types.usage import Usage as AnthropicUsage
 except ImportError as error:
     msg = "To use AnthropicChatModel you must install the `anthropic` package using `pip install 'magentic[anthropic]'`."
     raise ImportError(msg) from error
@@ -258,13 +256,60 @@ def _extract_system_message(
     )
 
 
-def _assistant_message(content: T, usage: AnthropicUsage) -> AssistantMessage[T]:
-    """Create an AssistantMessage with the given content and Anthropic usage onject."""
-    _usage = Usage(
-        input_tokens=usage.input_tokens,
-        output_tokens=usage.output_tokens,
-    )
-    return _assistant_message_with_usage(content, usage_pointer=[_usage])
+def _create_usage_ref(
+    response: Iterable[ToolsBetaMessageStreamEvent],
+) -> tuple[list[Usage], Iterator[ToolsBetaMessageStreamEvent]]:
+    """Returns a pointer to a Usage object that is created at the end of the response."""
+    usage_ref = []
+
+    def generator(
+        response: Iterable[ToolsBetaMessageStreamEvent],
+    ) -> Iterator[ToolsBetaMessageStreamEvent]:
+        message_start_usage = None
+        output_tokens = None
+        for chunk in response:
+            if chunk.type == "message_start":
+                message_start_usage = chunk.message.usage
+            if chunk.type == "message_delta":
+                output_tokens = chunk.usage.output_tokens
+            yield chunk
+        if message_start_usage and output_tokens:
+            usage_ref.append(
+                Usage(
+                    input_tokens=message_start_usage.input_tokens,
+                    output_tokens=message_start_usage.output_tokens + output_tokens,
+                )
+            )
+
+    return usage_ref, generator(response)
+
+
+def _create_usage_ref_async(
+    response: AsyncIterable[ToolsBetaMessageStreamEvent],
+) -> tuple[list[Usage], AsyncIterator[ToolsBetaMessageStreamEvent]]:
+    """Async version of `_create_usage_ref`."""
+    usage_ref = []
+
+    async def agenerator(
+        response: AsyncIterable[ToolsBetaMessageStreamEvent],
+    ) -> AsyncIterator[ToolsBetaMessageStreamEvent]:
+        message_start_usage = None
+        output_tokens = None
+        async for chunk in response:
+            if chunk.type == "message_start":
+                message_start_usage = chunk.message.usage
+            if chunk.type == "message_delta":
+                output_tokens = chunk.usage.output_tokens
+            yield chunk
+        if message_start_usage and output_tokens:
+            usage_ref.append(
+                Usage(
+                    input_tokens=message_start_usage.input_tokens,
+                    output_tokens=message_start_usage.output_tokens + output_tokens,
+                )
+            )
+
+    return usage_ref, agenerator(response)
 
 
 R = TypeVar("R")
@@ -404,6 +449,8 @@ class AnthropicChatModel(ChatModel):
                 yield from stream
 
         response = _response_generator()
+        usage_ref, response = _create_usage_ref(response)
+
         first_chunk = next(response)
         if first_chunk.type == "message_start":
             first_chunk = next(response)
@@ -425,7 +472,7 @@ class AnthropicChatModel(ChatModel):
                 allow_string_output=allow_string_output,
                 streamed=streamed_str_in_output_types,
             )
-            return _assistant_message(str_content, response.usage)  # type: ignore[return-value]
+            return AssistantMessage._with_usage(str_content, usage_ref)  # type: ignore[return-value]
 
         if (
             first_chunk.type == "content_block_start"
@@ -436,11 +483,11 @@ class AnthropicChatModel(ChatModel):
                     content = ParallelFunctionCall(
                         parse_streamed_tool_calls(response, tool_schemas)
                     )
-                    return _assistant_message(content, response.usage)  # type: ignore[return-value]
+                    return AssistantMessage._with_usage(content, usage_ref)  # type: ignore[return-value]
                 # Take only the first tool_call, silently ignore extra chunks
                 # TODO: Create generator here that raises error or warns if multiple tool_calls
                 content = next(parse_streamed_tool_calls(response, tool_schemas))
-                return _assistant_message(content, response.usage)  # type: ignore[return-value]
+                return AssistantMessage._with_usage(content, usage_ref)  # type: ignore[return-value]
             except ValidationError as e:
                 msg = (
                     "Failed to parse model output. You may need to update your prompt"
@@ -521,6 +568,8 @@ class AnthropicChatModel(ChatModel):
                     yield chunk
 
         response = _response_generator()
+        usage_ref, response = _create_usage_ref_async(response)
+
         first_chunk = await anext(response)
         if first_chunk.type == "message_start":
             first_chunk = await anext(response)
@@ -542,7 +591,7 @@ class AnthropicChatModel(ChatModel):
                 allow_string_output=allow_string_output,
                 streamed=async_streamed_str_in_output_types,
             )
-            return _assistant_message(str_content, response.usage)  # type: ignore[return-value]
+            return AssistantMessage._with_usage(str_content, usage_ref)  # type: ignore[return-value]
 
         if (
             first_chunk.type == "content_block_start"
@@ -553,13 +602,13 @@ class AnthropicChatModel(ChatModel):
                     content = AsyncParallelFunctionCall(
                         aparse_streamed_tool_calls(response, tool_schemas)
                     )
-                    return _assistant_message(content, response.usage)  # type: ignore[return-value]
+                    return AssistantMessage._with_usage(content, usage_ref)  # type: ignore[return-value]
                 # Take only the first tool_call, silently ignore extra chunks
                 # TODO: Create generator here that raises error or warns if multiple tool_calls
                 content = await anext(
                     aparse_streamed_tool_calls(response, tool_schemas)
                 )
-                return _assistant_message(content, response.usage)  # type: ignore[return-value]
+                return AssistantMessage._with_usage(content, usage_ref)  # type: ignore[return-value]
             except ValidationError as e:
                 msg = (
                     "Failed to parse model output. You may need to update your prompt"

--- a/src/magentic/chat_model/function_schema.py
+++ b/src/magentic/chat_model/function_schema.py
@@ -198,15 +198,6 @@ class IterableFunctionSchema(FunctionSchema[IterableT], Generic[IterableT]):
             self._item_type_adapter.validate_json(item)
             for item in iter_streamed_json_array(chunks)
         )
-        # Return the generator directly for abstract types
-        # Otherwise pydantic ValidatorIterator will be returned which breaks the
-        # callbacks for the end of the stream because it can't be printed from inside
-        # the generator while it's running.
-        if (get_origin(self._output_type) or self._output_type) in (
-            typing.Iterable,
-            typing.Iterator,
-        ) or is_origin_abstract(self._output_type):
-            return iter_items  # type: ignore[return-value]
         return self._model.model_validate({"value": iter_items}).value
 
     def serialize_args(self, value: IterableT) -> str:

--- a/src/magentic/chat_model/function_schema.py
+++ b/src/magentic/chat_model/function_schema.py
@@ -198,6 +198,15 @@ class IterableFunctionSchema(FunctionSchema[IterableT], Generic[IterableT]):
             self._item_type_adapter.validate_json(item)
             for item in iter_streamed_json_array(chunks)
         )
+        # Return the generator directly for abstract types
+        # Otherwise pydantic ValidatorIterator will be returned which breaks the
+        # callbacks for the end of the stream because it can't be printed from inside
+        # the generator while it's running.
+        if (get_origin(self._output_type) or self._output_type) in (
+            typing.Iterable,
+            typing.Iterator,
+        ) or is_origin_abstract(self._output_type):
+            return iter_items  # type: ignore[return-value]
         return self._model.model_validate({"value": iter_items}).value
 
     def serialize_args(self, value: IterableT) -> str:

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -87,7 +87,13 @@ class Usage(NamedTuple):
 class AssistantMessage(Message[ContentT], Generic[ContentT]):
     """A message received from an LLM chat model."""
 
-    usage: Usage | None = None
+    _usage_pointer: list[Usage] | None = None
+
+    @property
+    def usage(self) -> Usage | None:
+        if self._usage_pointer:
+            return self._usage_pointer[0]
+        return None
 
     @overload
     def format(

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -80,8 +80,8 @@ class UserMessage(Message[str]):
 class Usage(NamedTuple):
     """Usage statistics for the LLM request."""
 
-    input_tokens: int | None = None
-    output_tokens: int | None = None
+    input_tokens: int
+    output_tokens: int
 
 
 class AssistantMessage(Message[ContentT], Generic[ContentT]):

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -115,6 +115,15 @@ class AssistantMessage(Message[ContentT], Generic[ContentT]):
         return AssistantMessage(self.content)
 
 
+def _assistant_message_with_usage(
+    content: ContentT, usage_pointer: list[Usage]
+) -> AssistantMessage[ContentT]:
+    """Create an AssistantMessage with usage statistics."""
+    message = AssistantMessage(content)
+    message._usage_pointer = usage_pointer
+    return message
+
+
 class FunctionResultMessage(Message[ContentT], Generic[ContentT]):
     """A message containing the result of a function call."""
 

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Awaitable,
     Generic,
+    NamedTuple,
     TypeVar,
     cast,
     get_origin,
@@ -76,8 +77,17 @@ class UserMessage(Message[str]):
         return UserMessage(self.content.format(**kwargs))
 
 
+class Usage(NamedTuple):
+    """Usage statistics for the LLM request."""
+
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+
 class AssistantMessage(Message[ContentT], Generic[ContentT]):
     """A message received from an LLM chat model."""
+
+    usage: Usage | None = None
 
     @overload
     def format(

--- a/src/magentic/chat_model/mistral_chat_model.py
+++ b/src/magentic/chat_model/mistral_chat_model.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Any, Callable, Iterable, Sequence, TypeVar, overload
 
 import openai
+from openai.types.chat import ChatCompletionStreamOptionsParam
 
 from magentic.chat_model.base import ChatModel
 from magentic.chat_model.message import AssistantMessage, Message
@@ -23,6 +24,10 @@ class _MistralToolChoice(Enum):
 
 class _MistralOpenaiChatModel(OpenaiChatModel):
     """Modified OpenaiChatModel to be compatible with Mistral API."""
+
+    @staticmethod
+    def _get_stream_options() -> ChatCompletionStreamOptionsParam | openai.NotGiven:
+        return openai.NOT_GIVEN
 
     @staticmethod
     def _get_tool_choice(  # type: ignore[override]

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -306,7 +306,7 @@ def _create_usage_pointer(
     """Returns a pointer to a Usage object that is created at the end of the response."""
     usage_pointer = []
 
-    def generator():
+    def generator() -> Iterator[ChatCompletionChunk]:
         for chunk in response:
             if chunk.usage:
                 usage = Usage(
@@ -325,7 +325,7 @@ def _acreate_usage_pointer(
     """Async version of `_create_usage_pointer`."""
     usage_pointer = []
 
-    async def generator():
+    async def generator() -> AsyncIterator[ChatCompletionChunk]:
         async for chunk in response:
             if chunk.usage:
                 usage = Usage(

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -285,7 +285,7 @@ def _create_usage_ref(
     response: Iterable[ChatCompletionChunk],
 ) -> tuple[list[Usage], Iterator[ChatCompletionChunk]]:
     """Returns a pointer to a Usage object that is created at the end of the response."""
-    usage_ref = []
+    usage_ref: list[Usage] = []
 
     def generator(
         response: Iterable[ChatCompletionChunk],
@@ -306,7 +306,7 @@ def _create_usage_ref_async(
     response: AsyncIterable[ChatCompletionChunk],
 ) -> tuple[list[Usage], AsyncIterator[ChatCompletionChunk]]:
     """Async version of `_create_usage_ref`."""
-    usage_ref = []
+    usage_ref: list[Usage] = []
 
     async def agenerator(
         response: AsyncIterable[ChatCompletionChunk],

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -8,6 +8,7 @@ import openai
 from openai.types.chat import (
     ChatCompletionChunk,
     ChatCompletionMessageParam,
+    ChatCompletionStreamOptionsParam,
     ChatCompletionToolChoiceOptionParam,
     ChatCompletionToolParam,
 )
@@ -417,6 +418,10 @@ class OpenaiChatModel(ChatModel):
         return self._temperature
 
     @staticmethod
+    def _get_stream_options() -> ChatCompletionStreamOptionsParam | openai.NotGiven:
+        return {"include_usage": True}
+
+    @staticmethod
     def _get_tool_choice(
         *,
         tool_schemas: Sequence[BaseFunctionToolSchema[Any]],
@@ -484,7 +489,7 @@ class OpenaiChatModel(ChatModel):
             seed=self.seed,
             stop=stop,
             stream=True,
-            stream_options={"include_usage": True},
+            stream_options=self._get_stream_options(),
             temperature=self.temperature,
             tools=[schema.to_dict() for schema in tool_schemas] or openai.NOT_GIVEN,
             tool_choice=self._get_tool_choice(
@@ -595,7 +600,7 @@ class OpenaiChatModel(ChatModel):
             seed=self.seed,
             stop=stop,
             stream=True,
-            stream_options={"include_usage": True},
+            stream_options=self._get_stream_options(),
             temperature=self.temperature,
             tools=[schema.to_dict() for schema in tool_schemas] or openai.NOT_GIVEN,
             tool_choice=self._get_tool_choice(

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -247,7 +247,7 @@ def _iter_streamed_tool_calls(
     all_tool_call_chunks = (
         tool_call
         for chunk in response
-        if chunk.choices[0].delta.tool_calls
+        if chunk.choices and chunk.choices[0].delta.tool_calls
         for tool_call in chunk.choices[0].delta.tool_calls
     )
     for _, tool_call_chunks in groupby(
@@ -275,7 +275,7 @@ async def _aiter_streamed_tool_calls(
     all_tool_call_chunks = (
         tool_call
         async for chunk in response
-        if chunk.choices[0].delta.tool_calls
+        if chunk.choices and chunk.choices[0].delta.tool_calls
         for tool_call in chunk.choices[0].delta.tool_calls
     )
     async for _, tool_call_chunks in agroupby(
@@ -459,6 +459,7 @@ class OpenaiChatModel(ChatModel):
             seed=self.seed,
             stop=stop,
             stream=True,
+            stream_options={"include_usage": True},
             temperature=self.temperature,
             tools=[schema.to_dict() for schema in tool_schemas] or openai.NOT_GIVEN,
             tool_choice=self._get_tool_choice(
@@ -482,7 +483,7 @@ class OpenaiChatModel(ChatModel):
             streamed_str = StreamedStr(
                 chunk.choices[0].delta.content
                 for chunk in response
-                if chunk.choices[0].delta.content is not None
+                if chunk.choices and chunk.choices[0].delta.content is not None
             )
             str_content = validate_str_content(
                 streamed_str,
@@ -568,6 +569,7 @@ class OpenaiChatModel(ChatModel):
             seed=self.seed,
             stop=stop,
             stream=True,
+            stream_options={"include_usage": True},
             temperature=self.temperature,
             tools=[schema.to_dict() for schema in tool_schemas] or openai.NOT_GIVEN,
             tool_choice=self._get_tool_choice(
@@ -591,7 +593,7 @@ class OpenaiChatModel(ChatModel):
             async_streamed_str = AsyncStreamedStr(
                 chunk.choices[0].delta.content
                 async for chunk in response
-                if chunk.choices[0].delta.content is not None
+                if chunk.choices and chunk.choices[0].delta.content is not None
             )
             str_content = await avalidate_str_content(
                 async_streamed_str,

--- a/tests/chat_model/test_anthropic_chat_model.py
+++ b/tests/chat_model/test_anthropic_chat_model.py
@@ -41,6 +41,17 @@ def test_anthropic_chat_model_complete_usage():
 
 
 @pytest.mark.anthropic
+def test_anthropic_chat_model_complete_usage_structured_output():
+    chat_model = AnthropicChatModel("claude-3-haiku-20240307")
+    message = chat_model.complete(
+        messages=[UserMessage("Count to 5")], output_types=[list[int]]
+    )
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.anthropic
 def test_anthropic_chat_model_complete_no_structured_output_error():
     chat_model = AnthropicChatModel("claude-3-haiku-20240307")
     # Should not raise StructuredOutputError because forced to make tool call
@@ -121,6 +132,18 @@ async def test_anthropic_chat_model_acomplete_usage():
         messages=[UserMessage("Say hello!")], output_types=[AsyncStreamedStr]
     )
     await message.content.to_string()  # Finish the stream
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.anthropic
+async def test_anthropic_chat_model_acomplete_usage_structured_output():
+    chat_model = AnthropicChatModel("claude-3-haiku-20240307")
+    message = await chat_model.acomplete(
+        messages=[UserMessage("Count to 5")], output_types=[list[int]]
+    )
     assert isinstance(message.usage, Usage)
     assert message.usage.input_tokens > 0
     assert message.usage.output_tokens > 0

--- a/tests/chat_model/test_message.py
+++ b/tests/chat_model/test_message.py
@@ -33,7 +33,9 @@ def test_user_message_format():
 def test_assistant_message_usage():
     assistant_message = AssistantMessage("Hello")
     assert assistant_message.usage is None
-    assistant_message._usage_pointer = [Usage(input_tokens=1, output_tokens=2)]
+    assistant_message = AssistantMessage._with_usage(
+        "Hello", [Usage(input_tokens=1, output_tokens=2)]
+    )
     assert assistant_message.usage == Usage(input_tokens=1, output_tokens=2)
 
 

--- a/tests/chat_model/test_message.py
+++ b/tests/chat_model/test_message.py
@@ -5,6 +5,7 @@ from magentic.chat_model.message import (
     AssistantMessage,
     FunctionResultMessage,
     Placeholder,
+    Usage,
     UserMessage,
 )
 from magentic.function_call import FunctionCall
@@ -27,6 +28,13 @@ def test_user_message_format():
     assert_type(user_message_formatted, UserMessage)
     assert_type(user_message_formatted.content, str)
     assert user_message_formatted == UserMessage("Hello world")
+
+
+def test_assistant_message_usage():
+    assistant_message = AssistantMessage("Hello")
+    assert assistant_message.usage is None
+    assistant_message._usage_pointer = [Usage(input_tokens=1, output_tokens=2)]
+    assert assistant_message.usage == Usage(input_tokens=1, output_tokens=2)
 
 
 def test_assistant_message_format_str():

--- a/tests/chat_model/test_openai_chat_model.py
+++ b/tests/chat_model/test_openai_chat_model.py
@@ -156,6 +156,17 @@ def test_openai_chat_model_complete_usage():
 
 
 @pytest.mark.openai
+def test_openai_chat_model_complete_usage_structured_output():
+    chat_model = OpenaiChatModel("gpt-3.5-turbo")
+    message = chat_model.complete(
+        messages=[UserMessage("Count to 5")], output_types=[list[int]]
+    )
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.openai
 def test_openai_chat_model_complete_no_structured_output_error():
     chat_model = OpenaiChatModel("gpt-3.5-turbo")
     # Should not raise StructuredOutputError because forced to make tool call
@@ -176,6 +187,18 @@ async def test_openai_chat_model_acomplete_usage():
         messages=[UserMessage("Say hello!")], output_types=[AsyncStreamedStr]
     )
     await message.content.to_string()  # Finish the stream
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.openai
+async def test_openai_chat_model_acomplete_usage_structured_output():
+    chat_model = OpenaiChatModel("gpt-3.5-turbo")
+    message = await chat_model.acomplete(
+        messages=[UserMessage("Count to 5")], output_types=[list[int]]
+    )
     assert isinstance(message.usage, Usage)
     assert message.usage.input_tokens > 0
     assert message.usage.output_tokens > 0


### PR DESCRIPTION
Resolves #74 

- Create new `Usage` class
- Add this as an optional attribute of `AssistantMessage`
- Wrap openai/anthropic response stream to set usage when encountered

Example of non-streamed response with usage immediately available

```python
from magentic import OpenaiChatModel, UserMessage

chat_model = OpenaiChatModel("gpt-3.5-turbo", seed=42)
message = chat_model.complete(messages=[UserMessage("Say hello!")])

print(message.usage)
# > Usage(input_tokens=10, output_tokens=9)
```

Example of streamed response where usage only becomes available after the stream has been processed

```python
from magentic import OpenaiChatModel, UserMessage
from magentic.streaming import StreamedStr

chat_model = OpenaiChatModel("gpt-3.5-turbo", seed=42)
message = chat_model.complete(messages=[UserMessage("Say hello!")], output_types=[StreamedStr])

print(message.usage)
# > `None` because stream has not be processed yet

# Process the stream (convert StreamedStr to str)
str(message.content)

print(message.usage)
# > Usage(input_tokens=10, output_tokens=9)
```