### PR TITLE
Switch AnthropicChatModel to use streaming

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -123,13 +123,13 @@ files = [
 
 [[package]]
 name = "anthropic"
-version = "0.25.7"
+version = "0.26.0"
 description = "The official Python library for the anthropic API"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "anthropic-0.25.7-py3-none-any.whl", hash = "sha256:419a276eb20cfb7ddaac03c7e28e4e12df3ace71bcf33071a68c9a03c0dfcbdd"},
-    {file = "anthropic-0.25.7.tar.gz", hash = "sha256:e7de4c8ba8e7e8248ad7f05ed9176634780b95b67c678d23915d8964c8a26f4e"},
+    {file = "anthropic-0.26.0-py3-none-any.whl", hash = "sha256:38fc415561d71dcf263b89da0cc6ecec498379b56256fc4242e9128bc707b283"},
+    {file = "anthropic-0.26.0.tar.gz", hash = "sha256:6aaffeb05d515cf9788eef57150a5f827f3786883628ccac71dbe5671ab6f44e"},
 ]
 
 [package.dependencies]
@@ -4093,4 +4093,4 @@ litellm = ["litellm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "b7a90da077d1b6b2af2778bf60299f547a32269ca874d245348d58dcec0fd1a9"
+content-hash = "5ee3492c9fd0cabdf66a87e65d5052c4c37007c320aa3aa7ab0af1282989b1f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/jackmpcollins/magentic"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-anthropic = {version = ">=0.23.0", optional = true}
+anthropic = {version = ">=0.26.0", optional = true}
 filetype = "*"
 litellm = {version = ">=1.36.0", optional = true}
 openai = ">=1.24.0"

--- a/tests/chat_model/test_anthropic_chat_model.py
+++ b/tests/chat_model/test_anthropic_chat_model.py
@@ -1,8 +1,7 @@
 import pytest
 
 from magentic.chat_model.anthropic_chat_model import AnthropicChatModel
-from magentic.chat_model.base import StructuredOutputError
-from magentic.chat_model.message import UserMessage
+from magentic.chat_model.message import Message, UserMessage
 from magentic.function_call import (
     AsyncParallelFunctionCall,
     FunctionCall,
@@ -29,15 +28,16 @@ def test_anthropic_chat_model_complete(prompt, output_types, expected_output_typ
 
 
 @pytest.mark.anthropic
-def test_anthropic_chat_model_complete_raise_structured_output_error():
+def test_openai_chat_model_complete_no_structured_output_error():
     chat_model = AnthropicChatModel("claude-3-haiku-20240307")
-    with pytest.raises(StructuredOutputError):
-        chat_model.complete(
-            messages=[
-                UserMessage("Tell me a short joke. Return a string, not a tool call.")
-            ],
-            output_types=[int, bool],
-        )
+    # Should not raise StructuredOutputError because forced to make tool call
+    message: Message[int | bool] = chat_model.complete(
+        messages=[
+            UserMessage("Tell me a short joke. Return a string, not a tool call.")
+        ],
+        output_types=[int, bool],
+    )
+    assert isinstance(message.content, int | bool)
 
 
 @pytest.mark.anthropic


### PR DESCRIPTION
- Bump Anthropic version to https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.26.0 to support tool_choice, streamed tool calls, and vision
- Update `AnthropicChatModel` to use streaming to support `StreamedStr`

Currently object streaming does not work due to arrays in tool calls not being streamed. Anthropic issue: https://github.com/anthropics/anthropic-sdk-python/issues/509

```python
from magentic import prompt, StreamedStr
from magentic.chat_model.anthropic_chat_model import AnthropicChatModel


@prompt(
    "Tell me about {topic}.",
    model=AnthropicChatModel("claude-3-opus-20240229"),
)
def tell_me_about(topic: str) -> StreamedStr: ...


for chunk in tell_me_about("chocolate"):
    print(chunk, end="", flush=True)
```