### PR TITLE
Use new `parallel_tool_calls` arg with OpenAI API

### DIFF
--- a/src/magentic/chat_model/mistral_chat_model.py
+++ b/src/magentic/chat_model/mistral_chat_model.py
@@ -42,6 +42,12 @@ class _MistralOpenaiChatModel(OpenaiChatModel):
         """
         return openai.NOT_GIVEN if allow_string_output else _MistralToolChoice.ANY.value
 
+    @staticmethod
+    def _get_parallel_tool_calls(
+        self, output_types: Iterable[type[R]]
+    ) -> bool | openai.NotGiven:
+        return openai.NOT_GIVEN
+
 
 R = TypeVar("R")
 

--- a/src/magentic/chat_model/mistral_chat_model.py
+++ b/src/magentic/chat_model/mistral_chat_model.py
@@ -42,9 +42,8 @@ class _MistralOpenaiChatModel(OpenaiChatModel):
         """
         return openai.NOT_GIVEN if allow_string_output else _MistralToolChoice.ANY.value
 
-    @staticmethod
     def _get_parallel_tool_calls(
-        self, output_types: Iterable[type[R]]
+        self, output_types: Iterable[type]
     ) -> bool | openai.NotGiven:
         return openai.NOT_GIVEN
 

--- a/src/magentic/chat_model/mistral_chat_model.py
+++ b/src/magentic/chat_model/mistral_chat_model.py
@@ -43,7 +43,7 @@ class _MistralOpenaiChatModel(OpenaiChatModel):
         return openai.NOT_GIVEN if allow_string_output else _MistralToolChoice.ANY.value
 
     def _get_parallel_tool_calls(
-        self, output_types: Iterable[type]
+        self, *, tools_specified: bool, output_types: Iterable[type]
     ) -> bool | openai.NotGiven:
         return openai.NOT_GIVEN
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -436,8 +436,10 @@ class OpenaiChatModel(ChatModel):
         return "required"
 
     def _get_parallel_tool_calls(
-        self, output_types: Iterable[type]
+        self, *, tools_specified: bool, output_types: Iterable[type]
     ) -> bool | openai.NotGiven:
+        if not tools_specified:  # Enforced by OpenAI API
+            return openai.NOT_GIVEN
         if self.api_type == "azure":
             return openai.NOT_GIVEN
         if is_any_origin_subclass(output_types, ParallelFunctionCall):
@@ -507,7 +509,9 @@ class OpenaiChatModel(ChatModel):
             tool_choice=self._get_tool_choice(
                 tool_schemas=tool_schemas, allow_string_output=allow_string_output
             ),
-            parallel_tool_calls=self._get_parallel_tool_calls(output_types),
+            parallel_tool_calls=self._get_parallel_tool_calls(
+                tools_specified=bool(tool_schemas), output_types=output_types
+            ),
         )
         usage_ref, response = _create_usage_ref(response)
 
@@ -619,7 +623,9 @@ class OpenaiChatModel(ChatModel):
             tool_choice=self._get_tool_choice(
                 tool_schemas=tool_schemas, allow_string_output=allow_string_output
             ),
-            parallel_tool_calls=self._get_parallel_tool_calls(output_types),
+            parallel_tool_calls=self._get_parallel_tool_calls(
+                tools_specified=bool(tool_schemas), output_types=output_types
+            ),
         )
         usage_ref, response = _create_usage_ref_async(response)
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -435,6 +435,13 @@ class OpenaiChatModel(ChatModel):
             return tool_schemas[0].as_tool_choice()
         return "required"
 
+    def _get_parallel_tool_calls(
+        self, output_types: Iterable[type[R]]
+    ) -> bool | openai.NotGiven:
+        if self.api_type == "azure":
+            return openai.NOT_GIVEN
+        return False if not is_any_origin_subclass(output_types, ParallelFunctionCall) else openai.NOT_GIVEN
+
     @overload
     def complete(
         self,
@@ -496,6 +503,7 @@ class OpenaiChatModel(ChatModel):
             tool_choice=self._get_tool_choice(
                 tool_schemas=tool_schemas, allow_string_output=allow_string_output
             ),
+            parallel_tool_calls=self._get_parallel_tool_calls(output_types),
         )
         usage_ref, response = _create_usage_ref(response)
 
@@ -607,6 +615,7 @@ class OpenaiChatModel(ChatModel):
             tool_choice=self._get_tool_choice(
                 tool_schemas=tool_schemas, allow_string_output=allow_string_output
             ),
+            parallel_tool_calls=self._get_parallel_tool_calls(output_types),
         )
         usage_ref, response = _create_usage_ref_async(response)
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -436,11 +436,15 @@ class OpenaiChatModel(ChatModel):
         return "required"
 
     def _get_parallel_tool_calls(
-        self, output_types: Iterable[type[R]]
+        self, output_types: Iterable[type]
     ) -> bool | openai.NotGiven:
         if self.api_type == "azure":
             return openai.NOT_GIVEN
-        return False if not is_any_origin_subclass(output_types, ParallelFunctionCall) else openai.NOT_GIVEN
+        if is_any_origin_subclass(output_types, ParallelFunctionCall):
+            return openai.NOT_GIVEN
+        if is_any_origin_subclass(output_types, AsyncParallelFunctionCall):
+            return openai.NOT_GIVEN
+        return False
 
     @overload
     def complete(


### PR DESCRIPTION
Closes #240 

> Use `parallel_tool_calls: false` to force a single function call from OpenAI when `ParallelFunctionCall` return type is not present.
>
> Introduced in https://github.com/openai/openai-python/releases/tag/v1.32.0
>
> docs: https://platform.openai.com/docs/guides/function-calling/parallel-function-calling