### PR TITLE
Reduce tool call id to be 9 characters

### DIFF
--- a/src/magentic/function_call.py
+++ b/src/magentic/function_call.py
@@ -25,8 +25,11 @@ P = ParamSpec("P")
 
 
 def _create_unique_id() -> str:
-    # OpenAI has max length of 29 chars for function call IDs
-    return uuid4().hex[:29]
+    # OpenAI has max length of 29 chars for function call IDs.
+    # Currently Mistral has a max length of 9 chars for function call IDs, which
+    # shares the same API spec.
+    # So we go with 9 chars for now.
+    return uuid4().hex[:9]
 
 
 class FunctionCall(Generic[T]):


### PR DESCRIPTION
Tweaks the length of the `tool_call` `id` to be 9 characters to be compatible with Mistral's API (which shares the same API spec as OpenAI).

@jackmpcollins, I'm not sure where the right place is to test the function calling flow I was using (which is with handling function callings manually, in combination with `@chatprompt`) for Mistral specifically, or whether you think this is unnecessary.

Closes #276.