### PR TITLE
Limit tool call id to 9 chars for Mistral

### DIFF
--- a/src/magentic/function_call.py
+++ b/src/magentic/function_call.py
@@ -25,8 +25,8 @@ P = ParamSpec("P")
 
 
 def _create_unique_id() -> str:
-    # OpenAI has max length of 29 chars for function call IDs
-    return uuid4().hex[:29]
+    # Mistral has max length of 9 chars for tool call IDs, and OpenAI 29 chars
+    return uuid4().hex[:9]
 
 
 class FunctionCall(Generic[T]):

--- a/tests/chat_model/test_mistral_chat_model.py
+++ b/tests/chat_model/test_mistral_chat_model.py
@@ -113,6 +113,9 @@ def test_mistral_chat_model_few_shot_prompt():
                     character="Albus Dumbledore",
                 )
             ),
+            # Mistral requires AssistantMessage after tool output
+            # TODO: Automatically add this in ChatModel.complete like for tool calls
+            AssistantMessage("."),
             UserMessage("What is your favorite quote from {movie}?"),
         ],
         output_types=[Quote],


### PR DESCRIPTION
Limit tool call id to 9 chars for Mistral.

Fixes #276 
Closes #277 