### PR TITLE
Switch `FunctionResultMessage` to use function_call_id not FunctionCall

### DIFF
--- a/docs/chat-prompting.md
+++ b/docs/chat-prompting.md
@@ -143,7 +143,7 @@ plus_1_2 = FunctionCall(plus, 1, 2)
 @chatprompt(
     UserMessage("Use the plus function to add 1 and 2."),
     AssistantMessage(plus_1_2),
-    FunctionResultMessage(3, plus_1_2),
+    FunctionResultMessage(3, plus_1_2.unique_id),
     UserMessage("Now add 4 to the result."),
     functions=[plus],
 )

--- a/src/magentic/chat.py
+++ b/src/magentic/chat.py
@@ -114,7 +114,7 @@ class Chat:
             function_call = self.last_message.content
             result = function_call()
             return self.add_message(
-                FunctionResultMessage(content=result, function_call=function_call)
+                FunctionResultMessage(content=result, unique_id=function_call.unique_id)
             )
 
         if isinstance(self.last_message.content, ParallelFunctionCall):
@@ -124,7 +124,9 @@ class Chat:
                 parallel_function_call(), parallel_function_call
             ):
                 chat = chat.add_message(
-                    FunctionResultMessage(content=result, function_call=function_call)
+                    FunctionResultMessage(
+                        content=result, unique_id=function_call.unique_id
+                    )
                 )
             return chat
 
@@ -139,7 +141,7 @@ class Chat:
             if inspect.isawaitable(result):
                 result = await result
             return self.add_message(
-                FunctionResultMessage(content=result, function_call=function_call)
+                FunctionResultMessage(content=result, unique_id=function_call.unique_id)
             )
 
         if isinstance(self.last_message.content, AsyncParallelFunctionCall):
@@ -150,7 +152,9 @@ class Chat:
                 async_parallel_function_call,
             ):
                 chat = chat.add_message(
-                    FunctionResultMessage(content=result, function_call=function_call)
+                    FunctionResultMessage(
+                        content=result, unique_id=function_call.unique_id
+                    )
                 )
             return chat
 

--- a/src/magentic/chat.py
+++ b/src/magentic/chat.py
@@ -114,7 +114,9 @@ class Chat:
             function_call = self.last_message.content
             result = function_call()
             return self.add_message(
-                FunctionResultMessage(content=result, unique_id=function_call.unique_id)
+                FunctionResultMessage(
+                    content=result, function_call_id=function_call.unique_id
+                )
             )
 
         if isinstance(self.last_message.content, ParallelFunctionCall):
@@ -125,7 +127,7 @@ class Chat:
             ):
                 chat = chat.add_message(
                     FunctionResultMessage(
-                        content=result, unique_id=function_call.unique_id
+                        content=result, function_call_id=function_call.unique_id
                     )
                 )
             return chat
@@ -141,7 +143,9 @@ class Chat:
             if inspect.isawaitable(result):
                 result = await result
             return self.add_message(
-                FunctionResultMessage(content=result, unique_id=function_call.unique_id)
+                FunctionResultMessage(
+                    content=result, function_call_id=function_call.unique_id
+                )
             )
 
         if isinstance(self.last_message.content, AsyncParallelFunctionCall):
@@ -153,7 +157,7 @@ class Chat:
             ):
                 chat = chat.add_message(
                     FunctionResultMessage(
-                        content=result, unique_id=function_call.unique_id
+                        content=result, function_call_id=function_call.unique_id
                     )
                 )
             return chat

--- a/src/magentic/chat_model/anthropic_chat_model.py
+++ b/src/magentic/chat_model/anthropic_chat_model.py
@@ -144,7 +144,7 @@ def _(message: FunctionResultMessage[Any]) -> MessageParam:
         "content": [
             {
                 "type": "tool_result",
-                "tool_use_id": message.unique_id,
+                "tool_use_id": message.function_call_id,
                 "content": json.loads(function_schema.serialize_args(message.content)),
             }
         ],

--- a/src/magentic/chat_model/anthropic_chat_model.py
+++ b/src/magentic/chat_model/anthropic_chat_model.py
@@ -144,7 +144,7 @@ def _(message: FunctionResultMessage[Any]) -> MessageParam:
         "content": [
             {
                 "type": "tool_result",
-                "tool_use_id": message.function_call._unique_id,
+                "tool_use_id": message.unique_id,
                 "content": json.loads(function_schema.serialize_args(message.content)),
             }
         ],

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -123,17 +123,19 @@ class AssistantMessage(Message[ContentT], Generic[ContentT]):
 class FunctionResultMessage(Message[ContentT], Generic[ContentT]):
     """A message containing the result of a function call."""
 
-    def __init__(self, content: ContentT, unique_id: str):
+    def __init__(self, content: ContentT, function_call_id: str):
         super().__init__(content)
-        self._unique_id = unique_id
+        self._function_call_id = function_call_id
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.content!r}, {self._unique_id!r})"
+        return (
+            f"{self.__class__.__name__}({self.content!r}, {self._function_call_id!r})"
+        )
 
     @property
-    def unique_id(self) -> str:
-        return self._unique_id
+    def function_call_id(self) -> str:
+        return self._function_call_id
 
     def format(self, **kwargs: Any) -> "FunctionResultMessage[ContentT]":
         del kwargs
-        return FunctionResultMessage(self.content, self._unique_id)
+        return FunctionResultMessage(self.content, self._function_call_id)

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import (
     Any,
-    Awaitable,
     Generic,
     NamedTuple,
     TypeVar,
@@ -11,8 +10,6 @@ from typing import (
 )
 
 from typing_extensions import Self
-
-from magentic.function_call import FunctionCall
 
 T = TypeVar("T")
 
@@ -126,31 +123,17 @@ class AssistantMessage(Message[ContentT], Generic[ContentT]):
 class FunctionResultMessage(Message[ContentT], Generic[ContentT]):
     """A message containing the result of a function call."""
 
-    @overload
-    def __init__(
-        self, content: ContentT, function_call: FunctionCall[Awaitable[ContentT]]
-    ): ...
-
-    @overload
-    def __init__(self, content: ContentT, function_call: FunctionCall[ContentT]): ...
-
-    def __init__(
-        self,
-        content: ContentT,
-        function_call: FunctionCall[Awaitable[ContentT]] | FunctionCall[ContentT],
-    ):
+    def __init__(self, content: ContentT, unique_id: str):
         super().__init__(content)
-        self._function_call = function_call
+        self._unique_id = unique_id
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.content!r}, {self._function_call!r})"
+        return f"{self.__class__.__name__}({self.content!r}, {self._unique_id!r})"
 
     @property
-    def function_call(
-        self,
-    ) -> FunctionCall[Awaitable[ContentT]] | FunctionCall[ContentT]:
-        return self._function_call
+    def unique_id(self) -> str:
+        return self._unique_id
 
     def format(self, **kwargs: Any) -> "FunctionResultMessage[ContentT]":
         del kwargs
-        return FunctionResultMessage(self.content, self._function_call)
+        return FunctionResultMessage(self.content, self._unique_id)

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -143,7 +143,7 @@ def _(message: FunctionResultMessage[Any]) -> ChatCompletionMessageParam:
     function_schema = function_schema_for_type(type(message.content))
     return {
         "role": OpenaiMessageRole.TOOL.value,
-        "tool_call_id": message.unique_id,
+        "tool_call_id": message.function_call_id,
         "content": function_schema.serialize_args(message.content),
     }
 

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -143,7 +143,7 @@ def _(message: FunctionResultMessage[Any]) -> ChatCompletionMessageParam:
     function_schema = function_schema_for_type(type(message.content))
     return {
         "role": OpenaiMessageRole.TOOL.value,
-        "tool_call_id": message.function_call._unique_id,
+        "tool_call_id": message.unique_id,
         "content": function_schema.serialize_args(message.content),
     }
 

--- a/src/magentic/function_call.py
+++ b/src/magentic/function_call.py
@@ -41,7 +41,7 @@ class FunctionCall(Generic[T]):
         self._kwargs = kwargs
 
         # Used to correlate function call with result on serialization
-        self._unique_id = _create_unique_id()
+        self._unique_id = _create_unique_id()  # TODO: Allow setting this via param
 
     def __call__(self) -> T:
         with logfire.span(
@@ -67,6 +67,11 @@ class FunctionCall(Generic[T]):
             ]
         )
         return f"{type(self).__name__}({self._function!r}, {args_kwargs_repr})"
+
+    @property
+    def unique_id(self) -> str:
+        """A unique identifier for the function call."""
+        return self._unique_id
 
     @property
     def function(self):

--- a/tests/chat_model/test_message.py
+++ b/tests/chat_model/test_message.py
@@ -8,7 +8,6 @@ from magentic.chat_model.message import (
     Usage,
     UserMessage,
 )
-from magentic.function_call import FunctionCall
 
 
 def test_placeholder():
@@ -64,11 +63,9 @@ def test_function_result_message_format():
     def plus(a: int, b: int) -> int:
         return a + b
 
-    function_result_message = FunctionResultMessage(3, FunctionCall(plus, 1, 2))
+    function_result_message = FunctionResultMessage(3, "unique_id")
     function_result_message_formatted = function_result_message.format(foo="bar")
 
     assert_type(function_result_message_formatted, FunctionResultMessage[int])
     assert_type(function_result_message_formatted.content, int)
-    assert function_result_message_formatted == FunctionResultMessage(
-        3, FunctionCall(plus, 1, 2)
-    )
+    assert function_result_message_formatted == FunctionResultMessage(3, "unique_id")

--- a/tests/chat_model/test_openai_chat_model.py
+++ b/tests/chat_model/test_openai_chat_model.py
@@ -83,10 +83,10 @@ def plus(a: int, b: int) -> int:
             },
         ),
         (
-            FunctionResultMessage(3, FunctionCall(plus, 1, 2)),
+            FunctionResultMessage(3, "unique_id"),
             {
                 "role": "tool",
-                "tool_call_id": ANY,
+                "tool_call_id": "unique_id",
                 "content": '{"value":3}',
             },
         ),

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 import pytest
 
 from magentic.chat import Chat
@@ -76,7 +78,7 @@ def test_exec_function_call():
     )
     chat = chat.exec_function_call()
     assert len(chat.messages) == 3
-    assert chat.messages[2] == FunctionResultMessage(3, FunctionCall(plus, 1, 2))
+    assert chat.messages[2] == FunctionResultMessage(3, ANY)
 
 
 def test_exec_function_call_parallel_function_call():
@@ -96,8 +98,8 @@ def test_exec_function_call_parallel_function_call():
     )
     chat = chat.exec_function_call()
     assert len(chat.messages) == 4
-    assert chat.messages[2] == FunctionResultMessage(3, FunctionCall(plus, 1, 2))
-    assert chat.messages[3] == FunctionResultMessage(7, FunctionCall(plus, 3, 4))
+    assert chat.messages[2] == FunctionResultMessage(3, ANY)
+    assert chat.messages[3] == FunctionResultMessage(7, ANY)
 
 
 def test_exec_function_call_raises():
@@ -126,7 +128,7 @@ async def test_aexec_function_call_async_function():
     )
     chat = await chat.aexec_function_call()
     assert len(chat.messages) == 3
-    assert chat.messages[2] == FunctionResultMessage(3, FunctionCall(aplus, 1, 2))
+    assert chat.messages[2] == FunctionResultMessage(3, ANY)
 
 
 @pytest.mark.asyncio
@@ -143,7 +145,7 @@ async def test_aexec_function_call_not_async_function():
     )
     chat = await chat.aexec_function_call()
     assert len(chat.messages) == 3
-    assert chat.messages[2] == FunctionResultMessage(3, FunctionCall(plus, 1, 2))
+    assert chat.messages[2] == FunctionResultMessage(3, ANY)
 
 
 @pytest.mark.asyncio
@@ -164,8 +166,8 @@ async def test_aexec_function_call_async_parallel_function_call():
     )
     chat = await chat.aexec_function_call()
     assert len(chat.messages) == 4
-    assert chat.messages[2] == FunctionResultMessage(3, FunctionCall(plus, 1, 2))
-    assert chat.messages[3] == FunctionResultMessage(7, FunctionCall(plus, 3, 4))
+    assert chat.messages[2] == FunctionResultMessage(3, ANY)
+    assert chat.messages[3] == FunctionResultMessage(7, ANY)
 
 
 @pytest.mark.asyncio

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -54,12 +54,12 @@ def test_escape_braces(text):
         (
             [
                 FunctionResultMessage(
-                    "Function result message with {param}", function_call=Mock()
+                    "Function result message with {param}", unique_id="unique_id"
                 )
             ],
             [
                 FunctionResultMessage(
-                    "Function result message with {param}", function_call=Mock()
+                    "Function result message with {param}", unique_id="unique_id"
                 )
             ],
         ),
@@ -179,7 +179,7 @@ def test_chatprompt_with_function_call_and_result():
     @chatprompt(
         UserMessage("Use the plus function to add 1 and 2."),
         AssistantMessage(plus_1_2),
-        FunctionResultMessage(3, plus_1_2),
+        FunctionResultMessage(3, plus_1_2.unique_id),
     )
     def do_math() -> str: ...
 

--- a/tests/test_chatprompt.py
+++ b/tests/test_chatprompt.py
@@ -54,12 +54,12 @@ def test_escape_braces(text):
         (
             [
                 FunctionResultMessage(
-                    "Function result message with {param}", unique_id="unique_id"
+                    "Function result message with {param}", function_call_id="unique_id"
                 )
             ],
             [
                 FunctionResultMessage(
-                    "Function result message with {param}", unique_id="unique_id"
+                    "Function result message with {param}", function_call_id="unique_id"
                 )
             ],
         ),


### PR DESCRIPTION
We just need the tool_call_id / unique_id from the `FunctionCall` instance, not the whole function call. When using LLM to error-handle we might not have a `FunctionCall` instance when resubmitting the tool call message to the LLM (e.g. error in generating a structured object return type) but it would be nice to still be able to use `FunctionResultMessage`.