### PR TITLE
Add support for OpenAI structured outputs

### DIFF
--- a/docs/function-calling.md
+++ b/docs/function-calling.md
@@ -198,3 +198,23 @@ def activate_oven(
     """Turn the oven on with the provided settings."""
     return f"Preheating to {temperature} F with mode {mode}"
 ```
+
+## ConfigDict
+
+Also like with `BaseModel`, pydantic's (or magentic's) `ConfigDict` can be used with functions to configure behavior. Under the hood, the function gets converted to a pydantic model, with every function parameter becoming a field on that model. See the [Structured Outputs](structured-outputs.md) docs page for more information including the list of configuration options added by magentic.
+
+```python hl_lines="3 7"
+from typing import Annotated, Literal
+
+from magentic import ConfigDict, with_config
+from pydantic import Field
+
+
+@with_config(ConfigDict(openai_strict=True))
+def activate_oven(
+    temperature: Annotated[int, Field(description="Temp in Fahrenheit", lt=500)],
+    mode: Literal["broil", "bake", "roast"],
+) -> str:
+    """Turn the oven on with the provided settings."""
+    return f"Preheating to {temperature} F with mode {mode}"
+```

--- a/docs/structured-outputs.md
+++ b/docs/structured-outputs.md
@@ -46,7 +46,40 @@ class Superhero(BaseModel):
 def create_superhero(name: str) -> Superhero: ...
 ```
 
+### ConfigDict
+
+Pydantic also supports configuring the `BaseModel` by setting the `model_config` attribute. Magentic extends pydantic's `ConfigDict` class to add the following additional configuration options
+
+- `openai_strict: bool` Indicates whether to use [OpenAI's Structured Outputs feature](https://platform.openai.com/docs/guides/structured-outputs/introduction).
+
+See the [pydantic Configuration docs](https://docs.pydantic.dev/latest/api/config/) for the inherited configuration options.
+
+```python hl_lines="1 6"
+from magentic import prompt, ConfigDict
+from pydantic import BaseModel
+
+
+class Superhero(BaseModel):
+    model_config = ConfigDict(openai_strict=True)
+
+    name: str
+    age: int
+    power: str
+    enemies: list[str]
+
+
+@prompt("Create a Superhero named {name}.")
+def create_superhero(name: str) -> Superhero: ...
+
+
+create_superhero("Garden Man")
+```
+
 ### JSON Schema
+
+> !!! note "OpenAI Structured Outputs"
+
+    Setting `openai_strict=True` results in a different JSON schema than that from `.model_json_schema()` being sent to the LLM.
 
 You can generate the JSON schema for the pydantic model using the `.model_json_schema()` method. This is what is sent to the LLM.
 

--- a/docs/structured-outputs.md
+++ b/docs/structured-outputs.md
@@ -77,9 +77,9 @@ create_superhero("Garden Man")
 
 ### JSON Schema
 
-> !!! note "OpenAI Structured Outputs"
+!!! note "OpenAI Structured Outputs"
 
-    Setting `openai_strict=True` results in a different JSON schema than that from `.model_json_schema()` being sent to the LLM.
+    Setting `openai_strict=True` results in a different JSON schema than that from `.model_json_schema()` being sent to the LLM. Use `openai.pydantic_function_tool(Superhero)` to generate the JSON schema in this case.
 
 You can generate the JSON schema for the pydantic model using the `.model_json_schema()` method. This is what is sent to the LLM.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2694,9 +2694,9 @@ files = [
 
 [package.dependencies]
 numpy = [
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -2959,8 +2959,8 @@ files = [
 annotated-types = ">=0.4.0"
 pydantic-core = "2.20.1"
 typing-extensions = [
-    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
     {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
+    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
 ]
 
 [package.extras]
@@ -4519,4 +4519,4 @@ litellm = ["litellm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "f8ae0610eb5d53056abe2cccf0c4a840ddfdc2dc803decda0b18fb57c075bca4"
+content-hash = "81037825d20d0e111516496924acc94599815623031edf1ef6b965092861693d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@
 name = "aiohappyeyeballs"
 version = "2.3.5"
 description = "Happy Eyeballs for asyncio"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "aiohappyeyeballs-2.3.5-py3-none-any.whl", hash = "sha256:4d6dea59215537dbc746e93e779caea8178c866856a721c9c660d7a5a7b8be03"},
@@ -15,7 +15,7 @@ files = [
 name = "aiohttp"
 version = "3.10.2"
 description = "Async http client/server framework (asyncio)"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "aiohttp-3.10.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:95213b3d79c7e387144e9cb7b9d2809092d6ff2c044cb59033aedc612f38fb6d"},
@@ -112,7 +112,7 @@ speedups = ["Brotli", "aiodns (>=3.2.0)", "brotlicffi"]
 name = "aiosignal"
 version = "1.3.1"
 description = "aiosignal: a list of registered asynchronous callbacks"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "aiosignal-1.3.1-py3-none-any.whl", hash = "sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"},
@@ -303,7 +303,7 @@ typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
@@ -907,7 +907,7 @@ files = [
 name = "frozenlist"
 version = "1.4.1"
 description = "A list-like structure which implements collections.abc.MutableSequence"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "frozenlist-1.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f9aa1878d1083b276b0196f2dfbe00c9b7e752475ed3b682025ff20c1c1f51ac"},
@@ -1358,7 +1358,7 @@ i18n = ["Babel (>=2.7)"]
 name = "jiter"
 version = "0.5.0"
 description = "Fast iterable JSON parser."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "jiter-0.5.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:b599f4e89b3def9a94091e6ee52e1d7ad7bc33e238ebb9c4c63f211d74822c3f"},
@@ -2151,7 +2151,7 @@ files = [
 name = "multidict"
 version = "6.0.5"
 description = "multidict implementation"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "multidict-6.0.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:228b644ae063c10e7f324ab1ab6b548bdf6f8b47f3ec234fef1093bc2735e5f9"},
@@ -2491,23 +2491,24 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.38.0"
+version = "1.41.0"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.7.1"
 files = [
-    {file = "openai-1.38.0-py3-none-any.whl", hash = "sha256:a19ef052f1676320f52183ae6f9775da6d888fbe3aec57886117163c095d9f7c"},
-    {file = "openai-1.38.0.tar.gz", hash = "sha256:30fb324bf452ecb1194ca7dbc64566a4d7aa054c6a5da857937ede7d517a220b"},
+    {file = "openai-1.41.0-py3-none-any.whl", hash = "sha256:3b6cca4571667f3e0800442ef8f2bfa6a6f3301c51776bc7626159a4d81c242c"},
+    {file = "openai-1.41.0.tar.gz", hash = "sha256:26b81f39b49dce92ff5d30c373625ddb212c2f1050e1574e456d18423730cdd0"},
 ]
 
 [package.dependencies]
 anyio = ">=3.5.0,<5"
 distro = ">=1.7.0,<2"
 httpx = ">=0.23.0,<1"
+jiter = ">=0.4.0,<1"
 pydantic = ">=1.9.0,<3"
 sniffio = "*"
 tqdm = ">4"
-typing-extensions = ">=4.7,<5"
+typing-extensions = ">=4.11,<5"
 
 [package.extras]
 datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
@@ -3290,7 +3291,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -3298,16 +3298,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -3324,7 +3316,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -3332,7 +3323,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -4408,7 +4398,7 @@ files = [
 name = "yarl"
 version = "1.9.4"
 description = "Yet another URL library"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "yarl-1.9.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a8c1df72eb746f4136fe9a2e72b0c9dc1da1cbd23b5372f94b5820ff8ae30e0e"},
@@ -4529,4 +4519,4 @@ litellm = ["litellm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "e068616f49f935587954d1e2d03ff3ad819a414ab8b9718d3d0785e78d317eac"
+content-hash = "f8ae0610eb5d53056abe2cccf0c4a840ddfdc2dc803decda0b18fb57c075bca4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ anthropic = {version = ">=0.27.0", optional = true}
 filetype = "*"
 litellm = {version = ">=1.41.12", optional = true}
 logfire-api = "*"
-openai = ">=1.26.0"
+openai = ">=1.40.0"
 pydantic = ">=2.0.0"
 pydantic-settings = ">=2.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ filetype = "*"
 litellm = {version = ">=1.41.12", optional = true}
 logfire-api = "*"
 openai = ">=1.40.0"
-pydantic = ">=2.0.0"
+pydantic = ">=2.7.0"
 pydantic-settings = ">=2.0.0"
 
 [tool.poetry.extras]

--- a/src/magentic/__init__.py
+++ b/src/magentic/__init__.py
@@ -1,4 +1,5 @@
 from ._pydantic import ConfigDict as ConfigDict
+from ._pydantic import with_config as with_config
 from .chat_model.message import AnyMessage as AnyMessage
 from .chat_model.message import AssistantMessage as AssistantMessage
 from .chat_model.message import FunctionResultMessage as FunctionResultMessage

--- a/src/magentic/__init__.py
+++ b/src/magentic/__init__.py
@@ -1,3 +1,4 @@
+from magentic._pydantic import ConfigDict as ConfigDict
 from magentic.chat_model.message import (
     AnyMessage,
     AssistantMessage,

--- a/src/magentic/__init__.py
+++ b/src/magentic/__init__.py
@@ -1,39 +1,17 @@
-from magentic._pydantic import ConfigDict as ConfigDict
-from magentic.chat_model.message import (
-    AnyMessage,
-    AssistantMessage,
-    FunctionResultMessage,
-    Placeholder,
-    SystemMessage,
-    ToolResultMessage,
-    UserMessage,
-)
-from magentic.chat_model.openai_chat_model import OpenaiChatModel
-from magentic.chatprompt import chatprompt
-from magentic.function_call import (
-    AsyncParallelFunctionCall,
-    FunctionCall,
-    ParallelFunctionCall,
-)
-from magentic.prompt_chain import prompt_chain
-from magentic.prompt_function import prompt
-from magentic.streaming import AsyncStreamedStr, StreamedStr
-
-__all__ = [
-    "AnyMessage",
-    "AssistantMessage",
-    "FunctionResultMessage",
-    "Placeholder",
-    "SystemMessage",
-    "ToolResultMessage",
-    "UserMessage",
-    "OpenaiChatModel",
-    "chatprompt",
-    "AsyncParallelFunctionCall",
-    "FunctionCall",
-    "ParallelFunctionCall",
-    "prompt_chain",
-    "prompt",
-    "AsyncStreamedStr",
-    "StreamedStr",
-]
+from ._pydantic import ConfigDict as ConfigDict
+from .chat_model.message import AnyMessage as AnyMessage
+from .chat_model.message import AssistantMessage as AssistantMessage
+from .chat_model.message import FunctionResultMessage as FunctionResultMessage
+from .chat_model.message import Placeholder as Placeholder
+from .chat_model.message import SystemMessage as SystemMessage
+from .chat_model.message import ToolResultMessage as ToolResultMessage
+from .chat_model.message import UserMessage as UserMessage
+from .chat_model.openai_chat_model import OpenaiChatModel as OpenaiChatModel
+from .chatprompt import chatprompt as chatprompt
+from .function_call import AsyncParallelFunctionCall as AsyncParallelFunctionCall
+from .function_call import FunctionCall as FunctionCall
+from .function_call import ParallelFunctionCall as ParallelFunctionCall
+from .prompt_chain import prompt_chain as prompt_chain
+from .prompt_function import prompt as prompt
+from .streaming import AsyncStreamedStr as AsyncStreamedStr
+from .streaming import StreamedStr as StreamedStr

--- a/src/magentic/_pydantic.py
+++ b/src/magentic/_pydantic.py
@@ -1,5 +1,20 @@
+from typing import Any, Callable, TypeVar
+
 from pydantic import ConfigDict as _ConfigDict
+from pydantic import with_config as _with_config
 
 
 class ConfigDict(_ConfigDict, total=False):
     openai_strict: bool
+
+
+T = TypeVar("T", bound=type | Callable[..., Any])
+
+
+# Relax type constraints to allow as function decorator
+def with_config(config: ConfigDict) -> Callable[[T], T]:
+    return _with_config(config)  # type: ignore[return-value]
+
+
+def get_pydantic_config(obj: Any) -> ConfigDict | None:
+    return getattr(obj, "__pydantic_config__", None)

--- a/src/magentic/_pydantic.py
+++ b/src/magentic/_pydantic.py
@@ -1,5 +1,7 @@
 from typing import Any, Callable, TypeVar
 
+import openai
+from pydantic import BaseModel
 from pydantic import ConfigDict as _ConfigDict
 from pydantic import with_config as _with_config
 
@@ -18,3 +20,20 @@ def with_config(config: ConfigDict) -> Callable[[T], T]:
 
 def get_pydantic_config(obj: Any) -> ConfigDict | None:
     return getattr(obj, "__pydantic_config__", None)
+
+
+# TODO: Use directly from pydantic when available
+# https://github.com/pydantic/pydantic/issues/5213
+def json_schema(model: type[BaseModel]) -> dict[str, Any]:
+    """Generates a JSON schema for a pydantic model.
+
+    If `openai_strict` is set to `True` in the model's config, a schema compatible with
+    OpenAI APIs strict mode is generated.
+    """
+    if model.model_config.get("openai_strict", False):
+        tool_param = openai.pydantic_function_tool(model)
+        return tool_param["function"].get("parameters", {})
+    model_schema = model.model_json_schema().copy()
+    model_schema.pop("title", None)
+    model_schema.pop("description", None)
+    return model_schema

--- a/src/magentic/_pydantic.py
+++ b/src/magentic/_pydantic.py
@@ -1,0 +1,5 @@
+from pydantic import ConfigDict as _ConfigDict
+
+
+class ConfigDict(_ConfigDict, total=False):
+    openai_strict: bool

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any, Generic, TypeVar, get_origin
 import pytest
 from pydantic import BaseModel, Field, create_model
 
-from magentic._pydantic import ConfigDict
+from magentic._pydantic import ConfigDict, with_config
 from magentic.chat_model.function_schema import (
     AnyFunctionSchema,
     AsyncIterableFunctionSchema,
@@ -611,6 +611,11 @@ def plus_with_basemodel(a: IntModel, b: IntModel) -> IntModel:
     return IntModel(value=a.value + b.value)
 
 
+@with_config(ConfigDict(openai_strict=True))
+def plus_with_config_openai_strict(a: int, b: int) -> int:
+    return a + b
+
+
 @pytest.mark.parametrize(
     ("function", "json_schema"),
     [
@@ -786,6 +791,23 @@ def plus_with_basemodel(a: IntModel, b: IntModel) -> IntModel:
                     "required": ["a", "b"],
                     "type": "object",
                 },
+            },
+        ),
+        (
+            plus_with_config_openai_strict,
+            {
+                "name": "plus_with_config_openai_strict",
+                "parameters": {
+                    "additionalProperties": False,
+                    "properties": {
+                        "a": {"title": "A", "type": "integer"},
+                        "b": {"title": "B", "type": "integer"},
+                    },
+                    "required": ["a", "b"],
+                    "title": "FuncModel",
+                    "type": "object",
+                },
+                "strict": True,
             },
         ),
     ],


### PR DESCRIPTION
- Extend pydantic's `ConfigDict` to add `openai_strict: bool`
- Enable pydantic config to be set on functions
- For all types, pass along the pydantic config (if present) to the pydantic model used for serialization in FunctionSchemas
- Try read pydantic config when converting type to JSON schema, and use openai strict converter if `openai_strict` is True
- Add to docs


Example

```python
from magentic import prompt, ConfigDict
from pydantic import BaseModel


class Superhero(BaseModel):
    model_config = ConfigDict(openai_strict=True)

    name: str
    age: int
    power: str
    enemies: list[str]


@prompt("Create a Superhero named {name}.")
def create_superhero(name: str) -> Superhero: ...


create_superhero("Garden Man")
```

See docs for more: http://localhost:8000/structured-outputs/#configdict

Related to #295 