### PR TITLE
Consume LLM output stream via returned objects to allow caching

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -84,9 +84,9 @@ for hero in create_superhero_team("The Food Dudes"):
 
 Some LLMs have the ability to generate text output and make tool calls in the same response. This allows them to perform chain-of-thought reasoning or provide additional context to the user. In magentic, the `StreamedResponse` (or `AsyncStreamedResponse`) class can be used to request this type of output. This object is an iterable of `StreamedStr` (or `AsyncStreamedStr`) and `FunctionCall` instances.
 
-!!! warning "Consuming StreamedStr"
+!!! tip "Consuming StreamedStr"
 
-    The StreamedStr object must be iterated over before the next item in the `StreamedResponse` is processed, otherwise the string output will be lost. This is because the `StreamedResponse` and `StreamedStr` share the same underlying generator, so advancing the `StreamedResponse` iterator skips over the `StreamedStr` items. The `StreamedStr` object has internal caching so after iterating over it once the chunks will remain available.
+    The StreamedStr object caches its chunks internally, so it does not have to be consumed immediately. This means you can iterate over the chunks as they are received, and/or use the StreamedStr object as a whole after the LLM has finished generating the output.
 
 In the example below, we request that the LLM generates a greeting and then calls a function to get the weather for two cities. The `StreamedResponse` object is then iterated over to print the output, and the `StreamedStr` and `FunctionCall` items are processed separately.
 

--- a/docs/structured-outputs.md
+++ b/docs/structured-outputs.md
@@ -150,7 +150,7 @@ print(hero_defeated)
 
 !!! warning "StreamedResponse"
 
-    It is now recommended to use `StreamedResponse` for chain-of-thought prompting, as this uses the LLM provider's native chain-of-thought capabilities. See [StreamedResponse](streaming.md#StreamedResponse) for more information.
+    It is now recommended to use `StreamedResponse` for chain-of-thought prompting, as this uses the LLM provider's native chain-of-thought capabilities. See [StreamedResponse](streaming.md#streamedresponse) for more information.
 
 Using a simple Python type as the return annotation might result in poor results as the LLM has no time to arrange its thoughts before answering. To allow the LLM to work through this "chain of thought" you can instead return a pydantic model with initial fields for explaining the final response.
 

--- a/src/magentic/streaming.py
+++ b/src/magentic/streaming.py
@@ -85,7 +85,7 @@ async def atakewhile(
         yield item
 
 
-def consume(iterator: Iterator[T]) -> None:
+def consume(iterator: Iterable[T]) -> None:
     """Consume an iterator."""
     collections.deque(iterator, maxlen=0)
 

--- a/tests/chat_model/test_anthropic_chat_model.py
+++ b/tests/chat_model/test_anthropic_chat_model.py
@@ -140,7 +140,9 @@ def test_anthropic_chat_model_complete_streamed_response():
     assert len(response_items) == 2
     streamed_str, function_call = response_items
     assert isinstance(streamed_str, StreamedStr)
+    assert len(streamed_str.to_string()) > 1  # Check StreamedStr was cached
     assert isinstance(function_call, FunctionCall)
+    assert function_call() is None  # Check FunctionCall is successfully called
 
 
 @pytest.mark.parametrize(
@@ -257,4 +259,6 @@ async def test_anthropic_chat_model_acomplete_async_streamed_response():
     assert len(response_items) == 2
     streamed_str, function_call = response_items
     assert isinstance(streamed_str, AsyncStreamedStr)
+    assert len(await streamed_str.to_string()) > 1  # Check AsyncStreamedStr was cached
     assert isinstance(function_call, FunctionCall)
+    assert function_call() is None  # Check FunctionCall is successfully called

--- a/tests/chat_model/test_openai_chat_model.py
+++ b/tests/chat_model/test_openai_chat_model.py
@@ -188,7 +188,9 @@ def test_openai_chat_model_complete_streamed_response():
     assert len(response_items) == 2
     streamed_str, function_call = response_items
     assert isinstance(streamed_str, StreamedStr)
+    assert len(streamed_str.to_string()) > 1  # Check StreamedStr was cached
     assert isinstance(function_call, FunctionCall)
+    assert function_call() is None  # Check FunctionCall is successfully called
 
 
 @pytest.mark.openai
@@ -290,7 +292,9 @@ async def test_openai_chat_model_acomplete_async_streamed_response():
     assert len(response_items) == 2
     streamed_str, function_call = response_items
     assert isinstance(streamed_str, AsyncStreamedStr)
+    assert len(await streamed_str.to_string()) > 1  # Check AsyncStreamedStr was cached
     assert isinstance(function_call, FunctionCall)
+    assert function_call() is None  # Check FunctionCall is successfully called
 
 
 @pytest.mark.openai


### PR DESCRIPTION
Consume any remaining chunks via `StreamedStr` or output object in `OutputStream` so that internal caching in these objects can be used.

This removes the need to process StreamedStr immediately when it is received, so I removed the warning from the docs.