### PR TITLE
Accept Sequence[Message] instead of list for Chat

### DIFF
--- a/src/magentic/chat.py
+++ b/src/magentic/chat.py
@@ -1,5 +1,5 @@
 import inspect
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, ParamSpec, TypeVar
 
 from magentic.backend import get_chat_model
@@ -37,7 +37,7 @@ class Chat:
 
     def __init__(
         self,
-        messages: list[Message[Any]] | None = None,
+        messages: Sequence[Message[Any]] | None = None,
         functions: Iterable[Callable[..., Any]] | None = None,
         output_types: Iterable[type[Any]] | None = None,
         model: ChatModel | None = None,


### PR DESCRIPTION
The initializer directly invokes `list` on `messages` anyway, and the other parameters are generic too.