### PR TITLE
Use public import for ChatCompletionStreamState

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "filetype>=1.2.0",
     "logfire-api>=0.1.0",
-    "openai>=1.40.0",
+    "openai>=1.56.0",
     "pydantic>=2.10.0",
     "pydantic-settings>=2.0.0",
     "typing-extensions>=4.5.0",

--- a/src/magentic/chat_model/litellm_chat_model.py
+++ b/src/magentic/chat_model/litellm_chat_model.py
@@ -2,7 +2,7 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Literal, TypeVar, cast, overload
 
 import openai
-from openai.lib.streaming.chat._completions import ChatCompletionStreamState
+from openai.lib.streaming.chat import ChatCompletionStreamState
 from openai.types.chat import ChatCompletionNamedToolChoiceParam
 
 from magentic._parsing import contains_string_type

--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -4,7 +4,7 @@ from functools import singledispatch
 from typing import Any, Generic, Literal, TypeVar, cast, overload
 
 import openai
-from openai.lib.streaming.chat._completions import ChatCompletionStreamState
+from openai.lib.streaming.chat import ChatCompletionStreamState
 from openai.types.chat import (
     ChatCompletionChunk,
     ChatCompletionContentPartParam,

--- a/uv.lock
+++ b/uv.lock
@@ -1446,7 +1446,7 @@ requires-dist = [
     { name = "filetype", specifier = ">=1.2.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.41.12" },
     { name = "logfire-api", specifier = ">=0.1.0" },
-    { name = "openai", specifier = ">=1.40.0" },
+    { name = "openai", specifier = ">=1.56.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
@@ -1985,7 +1985,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.54.4"
+version = "1.59.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1997,9 +1997,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/95/83845be5ddd46ce0a35fd602a3366ec2d7fd6b2be6fb760ca553e2488ea1/openai-1.54.4.tar.gz", hash = "sha256:50f3656e45401c54e973fa05dc29f3f0b0d19348d685b2f7ddb4d92bf7b1b6bf", size = 314159 }
+sdist = { url = "https://files.pythonhosted.org/packages/73/d0/def3c7620e1cb446947f098aeac9d88fc826b1760d66da279e4712d37666/openai-1.59.3.tar.gz", hash = "sha256:7f7fff9d8729968588edf1524e73266e8593bb6cab09298340efb755755bb66f", size = 344192 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/d8/3e4cf8a5f544bef575d3502fedd81a15e317f591022de940647bdd0cc017/openai-1.54.4-py3-none-any.whl", hash = "sha256:0d95cef99346bf9b6d7fbf57faf61a673924c3e34fa8af84c9ffe04660673a7e", size = 389581 },
+    { url = "https://files.pythonhosted.org/packages/c7/26/0e0fb582bcb2a7cb6802447a749a2fc938fe4b82324097abccb86abfd5d1/openai-1.59.3-py3-none-any.whl", hash = "sha256:b041887a0d8f3e70d1fc6ffbb2bf7661c3b9a2f3e806c04bf42f572b9ac7bc37", size = 454793 },
 ]
 
 [[package]]


### PR DESCRIPTION
ChatCompletionStreamState was made public in https://github.com/openai/openai-python/releases/tag/v1.56.0 so switch to using that.

related issue: https://github.com/openai/openai-python/issues/1833