### PR TITLE
Remove unused content None from openai messages

### DIFF
--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -133,7 +133,6 @@ def _(message: AssistantMessage[Any]) -> ChatCompletionMessageParam:
         function_schema = FunctionCallFunctionSchema(message.content.function)
         return {
             "role": OpenaiMessageRole.ASSISTANT.value,
-            "content": None,
             "tool_calls": [
                 {
                     "id": message.content._unique_id,
@@ -149,7 +148,6 @@ def _(message: AssistantMessage[Any]) -> ChatCompletionMessageParam:
     if isinstance(message.content, ParallelFunctionCall):
         return {
             "role": OpenaiMessageRole.ASSISTANT.value,
-            "content": None,
             "tool_calls": [
                 {
                     "id": function_call._unique_id,
@@ -194,7 +192,6 @@ def _(message: AssistantMessage[Any]) -> ChatCompletionMessageParam:
     function_schema = function_schema_for_type(type(message.content))
     return {
         "role": OpenaiMessageRole.ASSISTANT.value,
-        "content": None,
         "tool_calls": [
             {
                 # Can be random because no result will be inserted back into the chat

--- a/tests/cassettes/test_chatprompt/test_chatprompt_readme_example.yaml
+++ b/tests/cassettes/test_chatprompt/test_chatprompt_readme_example.yaml
@@ -2,17 +2,16 @@ interactions:
 - request:
     body: '{"messages": [{"role": "system", "content": "You are a movie buff."}, {"role":
       "user", "content": "What is your favorite quote from Harry Potter?"}, {"role":
-      "assistant", "content": null, "tool_calls": [{"id": "000000000", "type": "function",
-      "function": {"name": "return_quote", "arguments": "{\"quote\":\"It does not
-      do to dwell on dreams and forget to live.\",\"character\":\"Albus Dumbledore\"}"}}]},
-      {"role": "tool", "tool_call_id": "000000000", "content": "null"}, {"role": "user",
-      "content": "What is your favorite quote from Iron Man?"}], "model": "gpt-4o",
-      "parallel_tool_calls": false, "stream": true, "stream_options": {"include_usage":
-      true}, "tool_choice": {"type": "function", "function": {"name": "return_quote"}},
-      "tools": [{"type": "function", "function": {"name": "return_quote", "parameters":
-      {"properties": {"quote": {"title": "Quote", "type": "string"}, "character":
-      {"title": "Character", "type": "string"}}, "required": ["quote", "character"],
-      "type": "object"}}}]}'
+      "assistant", "tool_calls": [{"id": "000000000", "type": "function", "function":
+      {"name": "return_quote", "arguments": "{\"quote\":\"It does not do to dwell
+      on dreams and forget to live.\",\"character\":\"Albus Dumbledore\"}"}}]}, {"role":
+      "tool", "tool_call_id": "000000000", "content": "null"}, {"role": "user", "content":
+      "What is your favorite quote from Iron Man?"}], "model": "gpt-4o", "parallel_tool_calls":
+      false, "stream": true, "stream_options": {"include_usage": true}, "tool_choice":
+      {"type": "function", "function": {"name": "return_quote"}}, "tools": [{"type":
+      "function", "function": {"name": "return_quote", "parameters": {"properties":
+      {"quote": {"title": "Quote", "type": "string"}, "character": {"title": "Character",
+      "type": "string"}}, "required": ["quote", "character"], "type": "object"}}}]}'
     headers:
       accept:
       - application/json
@@ -21,13 +20,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '988'
+      - '971'
       content-type:
       - application/json
       host:
       - api.openai.com
       user-agent:
-      - OpenAI/Python 1.54.4
+      - OpenAI/Python 1.59.3
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -37,7 +36,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.54.4
+      - 1.59.3
       x-stainless-retry-count:
       - '0'
       x-stainless-runtime:
@@ -48,56 +47,56 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_ClHm8dDnFk3Wtq2v0kk5vZvK","type":"function","function":{"name":"return_quote","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+      string: 'data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_DWCoPgZ6a1kfCtlW5ftA8C4D","type":"function","function":{"name":"return_quote","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"quote"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"quote"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"I"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"I"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
         am"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
         Iron"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
         Man"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":".\",\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":".\",\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"character"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"character"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Tony"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Tony"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
         Stark"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDHV0YBg92gya2uKkeGWxPbIS4N","object":"chat.completion.chunk","created":1732409787,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[],"usage":{"prompt_tokens":125,"completion_tokens":13,"total_tokens":138,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+        data: {"id":"chatcmpl-AokerhRojPD1bKjnMDI89GBsH4eyu","object":"chat.completion.chunk","created":1736659117,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[],"usage":{"prompt_tokens":125,"completion_tokens":13,"total_tokens":138,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
 
 
         data: [DONE]
@@ -108,13 +107,13 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8e7570710c5c17e2-SJC
+      - 900aafdbe9aa2f2e-LAX
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sun, 24 Nov 2024 00:56:27 GMT
+      - Sun, 12 Jan 2025 05:18:37 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -126,7 +125,7 @@ interactions:
       alt-svc:
       - h3=":443"; ma=86400
       openai-processing-ms:
-      - '492'
+      - '231'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -144,7 +143,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 100ms
       x-request-id:
-      - req_6b2623fe248b7024f7c51d3d1a0f730c
+      - req_b749276b21ce7d0ceebaf8ea5f351d25
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_chatprompt/test_chatprompt_with_function_call_and_result.yaml
+++ b/tests/cassettes/test_chatprompt/test_chatprompt_with_function_call_and_result.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
     body: '{"messages": [{"role": "user", "content": "Use the plus function to add
-      1 and 2."}, {"role": "assistant", "content": null, "tool_calls": [{"id": "000000000",
-      "type": "function", "function": {"name": "plus", "arguments": "{\"a\":1,\"b\":2}"}}]},
+      1 and 2."}, {"role": "assistant", "tool_calls": [{"id": "000000000", "type":
+      "function", "function": {"name": "plus", "arguments": "{\"a\":1,\"b\":2}"}}]},
       {"role": "tool", "tool_call_id": "000000000", "content": "{\"value\":3}"}],
       "model": "gpt-4o", "stream": true, "stream_options": {"include_usage": true}}'
     headers:
@@ -13,13 +13,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '398'
+      - '381'
       content-type:
       - application/json
       host:
       - api.openai.com
       user-agent:
-      - OpenAI/Python 1.54.4
+      - OpenAI/Python 1.59.3
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -29,7 +29,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.54.4
+      - 1.59.3
       x-stainless-retry-count:
       - '0'
       x-stainless-runtime:
@@ -40,56 +40,56 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+      string: 'data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"
         sum"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"
         of"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"
         "},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"1"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"1"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"
         and"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"
         "},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"
         is"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"
         "},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"3"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"3"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AWvDIRQh9f5YXVT8XzqKgnPFgk3Ix","object":"chat.completion.chunk","created":1732409788,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[],"usage":{"prompt_tokens":48,"completion_tokens":12,"total_tokens":60,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+        data: {"id":"chatcmpl-Aokes30cqRn8A69mQoiZ1oprIPtZC","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[],"usage":{"prompt_tokens":48,"completion_tokens":12,"total_tokens":60,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
 
 
         data: [DONE]
@@ -100,13 +100,13 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8e7570762c13270c-SJC
+      - 900aafdf888d7cf8-LAX
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sun, 24 Nov 2024 00:56:28 GMT
+      - Sun, 12 Jan 2025 05:18:38 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -118,7 +118,7 @@ interactions:
       alt-svc:
       - h3=":443"; ma=86400
       openai-processing-ms:
-      - '288'
+      - '273'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -130,13 +130,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '499'
       x-ratelimit-remaining-tokens:
-      - '29958'
+      - '29969'
       x-ratelimit-reset-requests:
       - 120ms
       x-ratelimit-reset-tokens:
-      - 83ms
+      - 62ms
       x-request-id:
-      - req_abfb62ec782d6511ea24e383bfbc67c5
+      - req_f72fe263fe5add274a533a615419c020
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_prompt_chain/test_async_prompt_chain.yaml
+++ b/tests/cassettes/test_prompt_chain/test_async_prompt_chain.yaml
@@ -21,7 +21,7 @@ interactions:
       host:
       - api.openai.com
       user-agent:
-      - AsyncOpenAI/Python 1.54.4
+      - AsyncOpenAI/Python 1.59.3
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -31,7 +31,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.54.4
+      - 1.59.3
       x-stainless-retry-count:
       - '0'
       x-stainless-runtime:
@@ -42,43 +42,28 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_OdGRePgCvnJSeHHjYuviwBrB","type":"function","function":{"name":"get_current_weather","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+      string: 'data: {"id":"chatcmpl-AokeuDhAxdQVgT8OQLHWK7vjdfDv7","object":"chat.completion.chunk","created":1736659120,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_Fsws9C0oAFDSeJ5IvzW18vfl","type":"function","function":{"name":"get_current_weather","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokeuDhAxdQVgT8OQLHWK7vjdfDv7","object":"chat.completion.chunk","created":1736659120,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"location"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokeuDhAxdQVgT8OQLHWK7vjdfDv7","object":"chat.completion.chunk","created":1736659120,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"location"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokeuDhAxdQVgT8OQLHWK7vjdfDv7","object":"chat.completion.chunk","created":1736659120,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Boston"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokeuDhAxdQVgT8OQLHWK7vjdfDv7","object":"chat.completion.chunk","created":1736659120,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Boston"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokeuDhAxdQVgT8OQLHWK7vjdfDv7","object":"chat.completion.chunk","created":1736659120,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"unit"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AokeuDhAxdQVgT8OQLHWK7vjdfDv7","object":"chat.completion.chunk","created":1736659120,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"fahren"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"heit"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AY7NvhQY8twSiXbZnXoHygtw9OZvK","object":"chat.completion.chunk","created":1732694903,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_831e067d82","choices":[],"usage":{"prompt_tokens":70,"completion_tokens":20,"total_tokens":90,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+        data: {"id":"chatcmpl-AokeuDhAxdQVgT8OQLHWK7vjdfDv7","object":"chat.completion.chunk","created":1736659120,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[],"usage":{"prompt_tokens":70,"completion_tokens":15,"total_tokens":85,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
 
 
         data: [DONE]
@@ -89,13 +74,13 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8e90a14a0c8d22d2-SJC
+      - 900aafebdbf308cb-LAX
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 27 Nov 2024 08:08:23 GMT
+      - Sun, 12 Jan 2025 05:18:40 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -107,7 +92,7 @@ interactions:
       alt-svc:
       - h3=":443"; ma=86400
       openai-processing-ms:
-      - '369'
+      - '241'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -125,16 +110,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 52ms
       x-request-id:
-      - req_29acff04284aaa4e4342f2af54d4a4b2
+      - req_72c5cacfe8b3d08ba04e168ef6c661d2
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages": [{"role": "user", "content": "What''s the weather like in
-      Boston?"}, {"role": "assistant", "content": null, "tool_calls": [{"id": "000000000",
-      "type": "function", "function": {"name": "get_current_weather", "arguments":
-      "{\"location\":\"Boston\",\"unit\":\"fahrenheit\"}"}}]}, {"role": "tool", "tool_call_id":
-      "000000000", "content": "{\"location\":\"Boston\",\"temperature\":\"72\",\"unit\":\"fahrenheit\",\"forecast\":[\"sunny\",\"windy\"]}"}],
+      Boston?"}, {"role": "assistant", "tool_calls": [{"id": "000000000", "type":
+      "function", "function": {"name": "get_current_weather", "arguments": "{\"location\":\"Boston\"}"}}]},
+      {"role": "tool", "tool_call_id": "000000000", "content": "{\"location\":\"Boston\",\"temperature\":\"72\",\"unit\":\"fahrenheit\",\"forecast\":[\"sunny\",\"windy\"]}"}],
       "model": "gpt-4o", "parallel_tool_calls": false, "stream": true, "stream_options":
       {"include_usage": true}, "tools": [{"type": "function", "function": {"name":
       "get_current_weather", "parameters": {"properties": {"location": {"title": "Location"},
@@ -148,13 +132,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '869'
+      - '828'
       content-type:
       - application/json
       host:
       - api.openai.com
       user-agent:
-      - AsyncOpenAI/Python 1.54.4
+      - AsyncOpenAI/Python 1.59.3
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -164,7 +148,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.54.4
+      - 1.59.3
       x-stainless-retry-count:
       - '0'
       x-stainless-runtime:
@@ -175,46 +159,47 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "data: {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+      string: "data: {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         current\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         weather\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         in\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         Boston\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         is\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        \"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata: {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"72\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\xB0F\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        \"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata: {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"72\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\xB0F\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         with\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         sunny\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         and\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         windy\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         conditions\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7Nw0Ld9DsdOxrbVxns7DBN8eA9a\",\"object\":\"chat.completion.chunk\",\"created\":1732694904,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_7f6be3efb0\",\"choices\":[],\"usage\":{\"prompt_tokens\":122,\"completion_tokens\":16,\"total_tokens\":138,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}}}\n\ndata:
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AokeuCBGSWPkUTAVsYLTBFybx79Ub\",\"object\":\"chat.completion.chunk\",\"created\":1736659120,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[],\"usage\":{\"prompt_tokens\":117,\"completion_tokens\":17,\"total_tokens\":134,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}}}\n\ndata:
         [DONE]\n\n"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8e90a14fcc6b67c7-SJC
+      - 900aafeefed469ac-LAX
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 27 Nov 2024 08:08:24 GMT
+      - Sun, 12 Jan 2025 05:18:40 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -226,7 +211,7 @@ interactions:
       alt-svc:
       - h3=":443"; ma=86400
       openai-processing-ms:
-      - '255'
+      - '167'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -244,7 +229,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 100ms
       x-request-id:
-      - req_700e5a9d06cbc5721c78aa22d0fbce6d
+      - req_410dabccc2ae98e1115f37ded5641bc8
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_prompt_chain/test_prompt_chain.yaml
+++ b/tests/cassettes/test_prompt_chain/test_prompt_chain.yaml
@@ -21,7 +21,7 @@ interactions:
       host:
       - api.openai.com
       user-agent:
-      - OpenAI/Python 1.54.4
+      - OpenAI/Python 1.59.3
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -31,7 +31,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.54.4
+      - 1.59.3
       x-stainless-retry-count:
       - '0'
       x-stainless-runtime:
@@ -42,28 +42,28 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-AY7NtLye868hzjFznwHUkCMpHwVn6","object":"chat.completion.chunk","created":1732694901,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_P3DrUvqprybs0ewD94G0ate8","type":"function","function":{"name":"get_current_weather","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+      string: 'data: {"id":"chatcmpl-Aokesjk0xpf5uKmUJle60nP2GpDkq","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_CTFfpmDnOAo8dQdXzcpLSZQq","type":"function","function":{"name":"get_current_weather","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NtLye868hzjFznwHUkCMpHwVn6","object":"chat.completion.chunk","created":1732694901,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokesjk0xpf5uKmUJle60nP2GpDkq","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NtLye868hzjFznwHUkCMpHwVn6","object":"chat.completion.chunk","created":1732694901,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"location"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokesjk0xpf5uKmUJle60nP2GpDkq","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"location"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NtLye868hzjFznwHUkCMpHwVn6","object":"chat.completion.chunk","created":1732694901,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokesjk0xpf5uKmUJle60nP2GpDkq","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NtLye868hzjFznwHUkCMpHwVn6","object":"chat.completion.chunk","created":1732694901,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Boston"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokesjk0xpf5uKmUJle60nP2GpDkq","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Boston"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NtLye868hzjFznwHUkCMpHwVn6","object":"chat.completion.chunk","created":1732694901,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-Aokesjk0xpf5uKmUJle60nP2GpDkq","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NtLye868hzjFznwHUkCMpHwVn6","object":"chat.completion.chunk","created":1732694901,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null}
+        data: {"id":"chatcmpl-Aokesjk0xpf5uKmUJle60nP2GpDkq","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AY7NtLye868hzjFznwHUkCMpHwVn6","object":"chat.completion.chunk","created":1732694901,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_7f6be3efb0","choices":[],"usage":{"prompt_tokens":70,"completion_tokens":15,"total_tokens":85,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+        data: {"id":"chatcmpl-Aokesjk0xpf5uKmUJle60nP2GpDkq","object":"chat.completion.chunk","created":1736659118,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_b7d65f1a5b","choices":[],"usage":{"prompt_tokens":70,"completion_tokens":15,"total_tokens":85,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
 
 
         data: [DONE]
@@ -74,13 +74,13 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8e90a13d0e5d17e6-SJC
+      - 900aafe35ca8cba4-LAX
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 27 Nov 2024 08:08:22 GMT
+      - Sun, 12 Jan 2025 05:18:39 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -92,7 +92,7 @@ interactions:
       alt-svc:
       - h3=":443"; ma=86400
       openai-processing-ms:
-      - '681'
+      - '384'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -110,16 +110,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 52ms
       x-request-id:
-      - req_0d1d0bcbe79f8af2fa00aab53e512b43
+      - req_8cc2b22fba6974c3a63ca873f2e5e3f7
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages": [{"role": "user", "content": "What''s the weather like in
-      Boston?"}, {"role": "assistant", "content": null, "tool_calls": [{"id": "000000000",
-      "type": "function", "function": {"name": "get_current_weather", "arguments":
-      "{\"location\":\"Boston\"}"}}]}, {"role": "tool", "tool_call_id": "000000000",
-      "content": "{\"location\":\"Boston\",\"temperature\":\"72\",\"unit\":\"fahrenheit\",\"forecast\":[\"sunny\",\"windy\"]}"}],
+      Boston?"}, {"role": "assistant", "tool_calls": [{"id": "000000000", "type":
+      "function", "function": {"name": "get_current_weather", "arguments": "{\"location\":\"Boston\"}"}}]},
+      {"role": "tool", "tool_call_id": "000000000", "content": "{\"location\":\"Boston\",\"temperature\":\"72\",\"unit\":\"fahrenheit\",\"forecast\":[\"sunny\",\"windy\"]}"}],
       "model": "gpt-4o", "parallel_tool_calls": false, "stream": true, "stream_options":
       {"include_usage": true}, "tools": [{"type": "function", "function": {"name":
       "get_current_weather", "parameters": {"properties": {"location": {"title": "Location"},
@@ -133,13 +132,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '845'
+      - '828'
       content-type:
       - application/json
       host:
       - api.openai.com
       user-agent:
-      - OpenAI/Python 1.54.4
+      - OpenAI/Python 1.59.3
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -149,7 +148,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.54.4
+      - 1.59.3
       x-stainless-retry-count:
       - '0'
       x-stainless-runtime:
@@ -160,46 +159,46 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "data: {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+      string: "data: {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         current\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         weather\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         in\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         Boston\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         is\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        \"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata: {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"72\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\xB0F\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        \"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata: {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"72\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\xB0F\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         with\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         sunny\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         and\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         windy\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
         conditions\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null}\n\ndata:
-        {\"id\":\"chatcmpl-AY7NutD05eI0kpgHRMnrDqTtYnvMW\",\"object\":\"chat.completion.chunk\",\"created\":1732694902,\"model\":\"gpt-4o-2024-08-06\",\"system_fingerprint\":\"fp_a7d06e42a7\",\"choices\":[],\"usage\":{\"prompt_tokens\":117,\"completion_tokens\":16,\"total_tokens\":133,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}}}\n\ndata:
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-AoketLO3SfKz7vJ20qZahVCMevfLq\",\"object\":\"chat.completion.chunk\",\"created\":1736659119,\"model\":\"gpt-4o-2024-08-06\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_b7d65f1a5b\",\"choices\":[],\"usage\":{\"prompt_tokens\":117,\"completion_tokens\":16,\"total_tokens\":133,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}}}\n\ndata:
         [DONE]\n\n"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8e90a1446b19270c-SJC
+      - 900aafe89ad4f644-LAX
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 27 Nov 2024 08:08:22 GMT
+      - Sun, 12 Jan 2025 05:18:39 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -211,7 +210,7 @@ interactions:
       alt-svc:
       - h3=":443"; ma=86400
       openai-processing-ms:
-      - '421'
+      - '170'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -229,7 +228,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 100ms
       x-request-id:
-      - req_039b14c0ae6a88154cd0e379aeae92e0
+      - req_da3bf6ac98c89cd6f6dd2afc600a30a4
     status:
       code: 200
       message: OK

--- a/tests/chat_model/cassettes/test_mistral_chat_model/test_mistral_chat_model_few_shot_prompt.yaml
+++ b/tests/chat_model/cassettes/test_mistral_chat_model/test_mistral_chat_model_few_shot_prompt.yaml
@@ -2,10 +2,10 @@ interactions:
 - request:
     body: '{"messages": [{"role": "system", "content": "You are a movie buff."}, {"role":
       "user", "content": "What is your favorite quote from Harry Potter?"}, {"role":
-      "assistant", "content": null, "tool_calls": [{"id": "000000000", "type": "function",
-      "function": {"name": "return_quote", "arguments": "{\"quote\":\"It does not
-      do to dwell on dreams and forget to live.\",\"character\":\"Albus Dumbledore\"}"}}]},
-      {"role": "tool", "tool_call_id": "000000000", "content": "null"}, {"role": "assistant",
+      "assistant", "tool_calls": [{"id": "000000000", "type": "function", "function":
+      {"name": "return_quote", "arguments": "{\"quote\":\"It does not do to dwell
+      on dreams and forget to live.\",\"character\":\"Albus Dumbledore\"}"}}]}, {"role":
+      "tool", "tool_call_id": "000000000", "content": "null"}, {"role": "assistant",
       "content": "."}, {"role": "user", "content": "What is your favorite quote from
       {movie}?"}], "model": "mistral-large-latest", "stream": true, "tool_choice":
       "any", "tools": [{"type": "function", "function": {"name": "return_quote", "parameters":
@@ -20,13 +20,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '914'
+      - '897'
       content-type:
       - application/json
       host:
       - api.mistral.ai
       user-agent:
-      - OpenAI/Python 1.54.4
+      - OpenAI/Python 1.59.3
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -36,7 +36,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.54.4
+      - 1.59.3
       x-stainless-retry-count:
       - '0'
       x-stainless-runtime:
@@ -47,10 +47,10 @@ interactions:
     uri: https://api.mistral.ai/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"b8ffbb14857d4d0fa4833410483e048f","object":"chat.completion.chunk","created":1732409785,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+      string: 'data: {"id":"60db5249cccd497a86a6e391d041494f","object":"chat.completion.chunk","created":1736659116,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
 
 
-        data: {"id":"b8ffbb14857d4d0fa4833410483e048f","object":"chat.completion.chunk","created":1732409785,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"tool_calls":[{"id":"cIwFIgNyc","function":{"name":"return_quote","arguments":"{\"quote\":
+        data: {"id":"60db5249cccd497a86a6e391d041494f","object":"chat.completion.chunk","created":1736659116,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"tool_calls":[{"id":"JdDHRctXt","function":{"name":"return_quote","arguments":"{\"quote\":
         \"May the Force be with you.\", \"character\": \"Obi-Wan Kenobi\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":185,"total_tokens":223,"completion_tokens":38}}
 
 
@@ -62,13 +62,13 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8e757066ba8b175e-SJC
+      - 900aafcb9a46171e-SJC
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sun, 24 Nov 2024 00:56:26 GMT
+      - Sun, 12 Jan 2025 05:18:37 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -84,15 +84,15 @@ interactions:
       ratelimitbysize-remaining:
       - '1967969'
       ratelimitbysize-reset:
-      - '35'
+      - '26'
       x-envoy-upstream-service-time:
-      - '1194'
+      - '2221'
       x-kong-proxy-latency:
-      - '1'
+      - '3'
       x-kong-request-id:
-      - 3627e2565677d509dc0d4a4a83ca3175
+      - 75058115a5adf01609a9bc5a00f2c921
       x-kong-upstream-latency:
-      - '1195'
+      - '2222'
       x-ratelimitbysize-limit-minute:
       - '2000000'
       x-ratelimitbysize-limit-month:
@@ -100,7 +100,7 @@ interactions:
       x-ratelimitbysize-remaining-minute:
       - '1967969'
       x-ratelimitbysize-remaining-month:
-      - '9998079275'
+      - '9999967969'
     status:
       code: 200
       message: OK

--- a/tests/chat_model/test_openai_chat_model.py
+++ b/tests/chat_model/test_openai_chat_model.py
@@ -60,7 +60,6 @@ def plus(a: int, b: int) -> int:
             AssistantMessage(42),
             {
                 "role": "assistant",
-                "content": None,
                 "tool_calls": [
                     {
                         "id": ANY,
@@ -74,7 +73,6 @@ def plus(a: int, b: int) -> int:
             AssistantMessage(FunctionCall(plus, 1, 2)),
             {
                 "role": "assistant",
-                "content": None,
                 "tool_calls": [
                     {
                         "id": ANY,
@@ -92,7 +90,6 @@ def plus(a: int, b: int) -> int:
             ),
             {
                 "role": "assistant",
-                "content": None,
                 "tool_calls": [
                     {
                         "id": ANY,


### PR DESCRIPTION
Remove the `"content": None,` from openai messages because it seems to be no longer needed as flagged by @alexchandel in https://github.com/jackmpcollins/magentic/issues/389#issuecomment-2552729053