### PR TITLE
fix - function call with no args when using anthropic api

### DIFF
--- a/src/magentic/chat_model/function_schema.py
+++ b/src/magentic/chat_model/function_schema.py
@@ -403,7 +403,8 @@ class FunctionCallFunctionSchema(FunctionSchema[FunctionCall[T]], Generic[T]):
         return cast(ConfigDict, self._model.model_config).get("openai_strict")
 
     def parse_args(self, chunks: Iterable[str]) -> FunctionCall[T]:
-        args_json = "".join(chunks)
+        # Anthropic message stream returns empty string for function call with no arguments
+        args_json = "".join(chunks) or "{}"
         model = self._model.model_validate_json(args_json)
         supplied_params = [
             param

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -2,7 +2,8 @@ import collections.abc
 import json
 import typing
 from collections import OrderedDict
-from typing import Annotated, Any, Callable, Generic, TypeVar, get_origin
+from collections.abc import Callable
+from typing import Annotated, Any, Generic, TypeVar, get_origin
 
 import pytest
 from pydantic import BaseModel, Field, create_model

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -876,19 +876,13 @@ function_call_function_schema_args_test_cases: FunctionSchemaArgTestCaseType = [
     ),
 ]
 
-function_call_function_schema_args_empty_string_test_case: FunctionSchemaArgTestCaseType = [
-    (
-        return_constant,
-        "",
-        FunctionCall(return_constant),
-    ),
-]
-
 
 @pytest.mark.parametrize(
     ("function", "args_str", "expected_args"),
-    function_call_function_schema_args_test_cases
-    + function_call_function_schema_args_empty_string_test_case,
+    [
+        *function_call_function_schema_args_test_cases,
+        (return_constant, "", FunctionCall(return_constant)),
+    ],
 )
 def test_function_call_function_schema_parse_args(function, args_str, expected_args):
     parsed_args = FunctionCallFunctionSchema(function).parse_args(args_str)

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -2,7 +2,6 @@ import collections.abc
 import json
 import typing
 from collections import OrderedDict
-from collections.abc import Callable
 from typing import Annotated, Any, Generic, TypeVar, get_origin
 
 import pytest
@@ -833,9 +832,7 @@ def test_function_call_function_schema_with_default_value():
     assert output() == 4
 
 
-FunctionSchemaArgTestCaseType = list[tuple[Callable[..., Any], str, FunctionCall[Any]]]
-
-function_call_function_schema_args_test_cases: FunctionSchemaArgTestCaseType = [
+function_call_function_schema_args_test_cases = [
     (plus, '{"a": 1, "b": 2}', FunctionCall(plus, 1, 2)),
     (
         plus_no_type_hints,

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -600,6 +600,10 @@ def plus_with_annotated(
     return a + b
 
 
+def return_constant() -> int:
+    return 100
+
+
 class IntModel(BaseModel):
     value: int
 
@@ -807,6 +811,13 @@ def plus_with_config_openai_strict(a: int, b: int) -> int:
                 "strict": True,
             },
         ),
+        (
+            return_constant,
+            {
+                "name": "return_constant",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        ),
     ],
 )
 def test_function_call_function_schema(function, json_schema):
@@ -855,12 +866,26 @@ function_call_function_schema_args_test_cases = [
         '{"a": {"value": 1}, "b": {"value": 2}}',
         FunctionCall(plus_with_basemodel, IntModel(value=1), IntModel(value=2)),
     ),
+    (
+        return_constant,
+        "{}",
+        FunctionCall(return_constant),
+    ),
+]
+
+function_call_function_schema_args_empty_string_test_case = [
+    (
+        return_constant,
+        "",
+        FunctionCall(return_constant),
+    ),
 ]
 
 
 @pytest.mark.parametrize(
     ("function", "args_str", "expected_args"),
-    function_call_function_schema_args_test_cases,
+    function_call_function_schema_args_test_cases
+    + function_call_function_schema_args_empty_string_test_case,
 )
 def test_function_call_function_schema_parse_args(function, args_str, expected_args):
     parsed_args = FunctionCallFunctionSchema(function).parse_args(args_str)

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -878,6 +878,7 @@ function_call_function_schema_args_test_cases = [
     ("function", "args_str", "expected_args"),
     [
         *function_call_function_schema_args_test_cases,
+        # Anthropic message stream returns empty string for function call with no arguments
         (return_constant, "", FunctionCall(return_constant)),
     ],
 )

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -2,7 +2,7 @@ import collections.abc
 import json
 import typing
 from collections import OrderedDict
-from typing import Annotated, Any, Generic, TypeVar, get_origin
+from typing import Annotated, Any, Callable, Generic, TypeVar, get_origin
 
 import pytest
 from pydantic import BaseModel, Field, create_model
@@ -832,7 +832,9 @@ def test_function_call_function_schema_with_default_value():
     assert output() == 4
 
 
-function_call_function_schema_args_test_cases = [
+FunctionSchemaArgTestCaseType = list[tuple[Callable[..., Any], str, FunctionCall[Any]]]
+
+function_call_function_schema_args_test_cases: FunctionSchemaArgTestCaseType = [
     (plus, '{"a": 1, "b": 2}', FunctionCall(plus, 1, 2)),
     (
         plus_no_type_hints,
@@ -873,7 +875,7 @@ function_call_function_schema_args_test_cases = [
     ),
 ]
 
-function_call_function_schema_args_empty_string_test_case = [
+function_call_function_schema_args_empty_string_test_case: FunctionSchemaArgTestCaseType = [
     (
         return_constant,
         "",


### PR DESCRIPTION
When the arguments string is empty, replace it with an empty json dict, so pydantic can parse it correctly.

Fixes #407 