### PR TITLE
Make Chat generic on LastMessageT and OutputT

### DIFF
--- a/src/magentic/_chat.py
+++ b/src/magentic/_chat.py
@@ -23,7 +23,7 @@ from magentic.prompt_function import BasePromptFunction
 from magentic.streaming import async_iter, azip
 
 LastMessageT = TypeVar("LastMessageT", bound=Message[Any])
-OutputT = TypeVar("OutputT", bound=type[Any], default=type[str])  # default to `str`
+OutputT = TypeVar("OutputT", bound=type[Any], default=type[str])
 MessageT = TypeVar("MessageT", bound=Message[Any])
 T = TypeVar("T")
 TypeT = TypeVar("TypeT", bound=type[Any])

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -86,6 +86,7 @@ ContentT = TypeVar("ContentT", covariant=True)
 class Message(BaseModel, Generic[ContentT], ABC):
     """A message sent to or from an LLM chat model."""
 
+    role: str
     content: ContentT
 
     def __init__(self, content: ContentT, **data: Any):
@@ -106,6 +107,8 @@ class _RawMessage(Message[ContentT], Generic[ContentT]):
     The content of this message should be a dict/object that matches the format
     expected by the LLM provider's Python client.
     """
+
+    role: Literal["_raw"] = "_raw"
 
     def __init__(self, content: ContentT, **data: Any):
         super().__init__(content=content, **data)

--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -375,4 +375,10 @@ AnyMessage = Annotated[
     SystemMessage | UserMessage[Any] | AssistantMessage[Any] | ToolResultMessage[Any],
     Field(discriminator="role"),
 ]
-"""Union of all message types."""
+"""Union of all message types.
+
+This type can be used for (de)serialization of `Message` objects, or as a return type
+in prompt-functions. This allows you to create prompt-functions to do things like
+summarize a chat history into fewer messages, or even to create a set of messages that
+you can use in a chatprompt-function.
+"""


### PR DESCRIPTION
Experiment for how `Chat` could be typed by making it generic on LastMessageT and OutputT. The `add_X_message` methods change the last message type based on the content provided. The `(a)submit` method changes the last message type to an `AssistantMessage[OutputT]`.