### PR TITLE
feat: support for passing extra_headers to LitellmChatModel

### DIFF
--- a/src/magentic/chat_model/litellm_chat_model.py
+++ b/src/magentic/chat_model/litellm_chat_model.py
@@ -128,7 +128,7 @@ class LitellmChatModel(ChatModel):
     @property
     def api_base(self) -> str | None:
         return self._api_base
-    
+
     @property
     def extra_headers(self) -> dict[str, str] | None:
         return self._extra_headers

--- a/src/magentic/chat_model/litellm_chat_model.py
+++ b/src/magentic/chat_model/litellm_chat_model.py
@@ -107,6 +107,7 @@ class LitellmChatModel(ChatModel):
         model: str,
         *,
         api_base: str | None = None,
+        extra_headers: dict[str, str] | None = None,
         max_tokens: int | None = None,
         metadata: dict[str, Any] | None = None,
         temperature: float | None = None,
@@ -114,6 +115,7 @@ class LitellmChatModel(ChatModel):
     ):
         self._model = model
         self._api_base = api_base
+        self._extra_headers = extra_headers
         self._max_tokens = max_tokens
         self._metadata = metadata
         self._temperature = temperature
@@ -126,6 +128,10 @@ class LitellmChatModel(ChatModel):
     @property
     def api_base(self) -> str | None:
         return self._api_base
+    
+    @property
+    def extra_headers(self) -> dict[str, str] | None:
+        return self._extra_headers
 
     @property
     def max_tokens(self) -> int | None:
@@ -176,6 +182,7 @@ class LitellmChatModel(ChatModel):
             messages=[message_to_openai_message(m) for m in messages],
             api_base=self.api_base,
             custom_llm_provider=self.custom_llm_provider,
+            extra_headers=self.extra_headers,
             max_tokens=self.max_tokens,
             metadata=self.metadata,
             stop=stop,
@@ -216,6 +223,7 @@ class LitellmChatModel(ChatModel):
             messages=[message_to_openai_message(m) for m in messages],
             api_base=self.api_base,
             custom_llm_provider=self.custom_llm_provider,
+            extra_headers=self.extra_headers,
             max_tokens=self.max_tokens,
             metadata=self.metadata,
             stop=stop,

--- a/tests/chat_model/cassettes/test_litellm_chat_model/test_litellm_chat_model_extra_headers.yaml
+++ b/tests/chat_model/cassettes/test_litellm_chat_model/test_litellm_chat_model_extra_headers.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{"model": "deepseek-coder-v2", "prompt": "### User:\nSay hello!\n\n", "options":
+      {}, "stream": true}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      cf-access-token:
+      - '...'
+      connection:
+      - keep-alive
+      content-length:
+      - '100'
+      host:
+      - ollama.orianna.ai
+      user-agent:
+      - litellm/1.60.8
+    method: POST
+    uri: https://ollama.orianna.ai/api/generate
+  response:
+    body:
+      string: '{"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.554571427Z","response":"
+        Hello","done":false}
+
+        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.571490903Z","response":"!","done":false}
+
+        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.587202718Z","response":"
+        How","done":false}
+
+        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.602207717Z","response":"
+        can","done":false}
+
+        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.617997682Z","response":"
+        I","done":false}
+
+        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.633654112Z","response":"
+        assist","done":false}
+
+        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.648182905Z","response":"
+        you","done":false}
+
+        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.663245681Z","response":"
+        today","done":false}
+
+        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.678022119Z","response":"?","done":false}
+
+        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.692794Z","response":"","done":true,"done_reason":"stop","context":[100000,5726,25,49757,10468,25,185,30445,39280,0,185,185,185,185,77398,25,37727,0,1724,481,304,4750,340,3571,30],"total_duration":4373170396,"load_duration":3905742418,"prompt_eval_count":17,"prompt_eval_duration":324000000,"eval_count":10,"eval_duration":142000000}
+
+        '
+    headers:
+      CF-RAY:
+      - 910189e5fc378cc0-EWR
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1358'
+      Content-Type:
+      - application/x-ndjson
+      Date:
+      - Tue, 11 Feb 2025 04:19:10 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=covxVw8m%2FzCV0nmwN7OuXxWrfwZ2Omrjs0RREoG%2F9PiauTFGJmK%2B0fADH4W33ONlBpYSJNJi%2FvEW%2BhRa1tw0zrvGTzBuF9R5y90sBdK7rSVCZv%2F2vwFGRo1hE23ZR%2B1KSljy9Q%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      server-timing:
+      - cfL4;desc="?proto=TCP&rtt=16478&min_rtt=15249&rtt_var=8178&sent=6&recv=8&lost=0&retrans=0&sent_bytes=3048&recv_bytes=1812&delivery_rate=163590&cwnd=245&unsent_bytes=0&cid=e417c28095331bb0&ts=4974&x=0"
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/chat_model/cassettes/test_litellm_chat_model/test_litellm_chat_model_extra_headers.yaml
+++ b/tests/chat_model/cassettes/test_litellm_chat_model/test_litellm_chat_model_extra_headers.yaml
@@ -1,77 +1,130 @@
 interactions:
 - request:
-    body: '{"model": "deepseek-coder-v2", "prompt": "### User:\nSay hello!\n\n", "options":
-      {}, "stream": true}'
+    body: '{"messages": [{"role": "user", "content": "Say hello!"}], "model": "gpt-4o",
+      "stream": true}'
     headers:
       accept:
-      - '*/*'
+      - application/json
       accept-encoding:
       - gzip, deflate
-      cf-access-token:
-      - '...'
       connection:
       - keep-alive
       content-length:
-      - '100'
+      - '92'
+      content-type:
+      - application/json
       host:
-      - ollama.orianna.ai
+      - api.openai.com
+      my-extra-header:
+      - foo
       user-agent:
-      - litellm/1.60.8
+      - OpenAI/Python 1.59.3
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.59.3
+      x-stainless-raw-response:
+      - 'true'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
     method: POST
-    uri: https://ollama.orianna.ai/api/generate
+    uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: '{"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.554571427Z","response":"
-        Hello","done":false}
+      string: 'data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}]}
 
-        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.571490903Z","response":"!","done":false}
 
-        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.587202718Z","response":"
-        How","done":false}
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}
 
-        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.602207717Z","response":"
-        can","done":false}
 
-        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.617997682Z","response":"
-        I","done":false}
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}]}
 
-        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.633654112Z","response":"
-        assist","done":false}
 
-        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.648182905Z","response":"
-        you","done":false}
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"content":"
+        How"},"logprobs":null,"finish_reason":null}]}
 
-        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.663245681Z","response":"
-        today","done":false}
 
-        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.678022119Z","response":"?","done":false}
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}]}
 
-        {"model":"deepseek-coder-v2","created_at":"2025-02-11T04:19:09.692794Z","response":"","done":true,"done_reason":"stop","context":[100000,5726,25,49757,10468,25,185,30445,39280,0,185,185,185,185,77398,25,37727,0,1724,481,304,4750,340,3571,30],"total_duration":4373170396,"load_duration":3905742418,"prompt_eval_count":17,"prompt_eval_duration":324000000,"eval_count":10,"eval_duration":142000000}
+
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"content":"
+        assist"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"content":"
+        you"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"content":"
+        today"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-B4PbRwwnGeGvQA5rvpj5ujPOkyrWc","object":"chat.completion.chunk","created":1740391429,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_eb9dce56a8","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+
+        data: [DONE]
+
 
         '
     headers:
       CF-RAY:
-      - 910189e5fc378cc0-EWR
+      - 916ea0c2c9bdcb94-LAX
       Connection:
       - keep-alive
-      Content-Length:
-      - '1358'
       Content-Type:
-      - application/x-ndjson
+      - text/event-stream; charset=utf-8
       Date:
-      - Tue, 11 Feb 2025 04:19:10 GMT
-      NEL:
-      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
-      Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=covxVw8m%2FzCV0nmwN7OuXxWrfwZ2Omrjs0RREoG%2F9PiauTFGJmK%2B0fADH4W33ONlBpYSJNJi%2FvEW%2BhRa1tw0zrvGTzBuF9R5y90sBdK7rSVCZv%2F2vwFGRo1hE23ZR%2B1KSljy9Q%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      - Mon, 24 Feb 2025 10:03:49 GMT
       Server:
       - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
       cf-cache-status:
       - DYNAMIC
-      server-timing:
-      - cfL4;desc="?proto=TCP&rtt=16478&min_rtt=15249&rtt_var=8178&sent=6&recv=8&lost=0&retrans=0&sent_bytes=3048&recv_bytes=1812&delivery_rate=163590&cwnd=245&unsent_bytes=0&cid=e417c28095331bb0&ts=4974&x=0"
+      openai-processing-ms:
+      - '325'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '500'
+      x-ratelimit-limit-tokens:
+      - '30000'
+      x-ratelimit-remaining-requests:
+      - '499'
+      x-ratelimit-remaining-tokens:
+      - '29980'
+      x-ratelimit-reset-requests:
+      - 120ms
+      x-ratelimit-reset-tokens:
+      - 40ms
+      x-request-id:
+      - req_c61d69127580a9d164ff2a701a16b787
     status:
       code: 200
       message: OK

--- a/tests/chat_model/test_litellm_chat_model.py
+++ b/tests/chat_model/test_litellm_chat_model.py
@@ -53,7 +53,7 @@ def litellm_success_callback_calls() -> Iterator[list[dict[str, Any]]]:
 def test_litellm_chat_model_extra_headers():
     """Test that provided extra_headers is passed to the litellm success callback."""
     chat_model = LitellmChatModel(
-        "ollama/deepseek-coder-v2", 
+        "ollama/deepseek-coder-v2",
         api_base="https://ollama.orianna.ai",
         extra_headers={"cf-access-token": "..."},
     )

--- a/tests/chat_model/test_litellm_chat_model.py
+++ b/tests/chat_model/test_litellm_chat_model.py
@@ -50,7 +50,7 @@ def litellm_success_callback_calls() -> Iterator[list[dict[str, Any]]]:
 
 
 @pytest.mark.litellm_ollama
-def test_litellm_chat_model_extra_headers(litellm_success_callback_calls):
+def test_litellm_chat_model_extra_headers():
     """Test that provided extra_headers is passed to the litellm success callback."""
     chat_model = LitellmChatModel(
         "ollama/deepseek-coder-v2", 
@@ -58,9 +58,8 @@ def test_litellm_chat_model_extra_headers(litellm_success_callback_calls):
         extra_headers={"cf-access-token": "..."},
     )
     assert chat_model.extra_headers == {"cf-access-token": "..."}
-    chat_model.complete(messages=[UserMessage("Say hello!")])
-    callback_call = litellm_success_callback_calls[0]
-    assert callback_call["kwargs"]["litellm_params"]["extra_headers"] == {"cf-access-token": "..."}
+    message = chat_model.complete(messages=[UserMessage("Say hello!")])
+    assert isinstance(message.content, str)
 
 
 @pytest.mark.litellm_openai

--- a/tests/chat_model/test_litellm_chat_model.py
+++ b/tests/chat_model/test_litellm_chat_model.py
@@ -50,6 +50,16 @@ def litellm_success_callback_calls() -> Iterator[list[dict[str, Any]]]:
 
 
 @pytest.mark.litellm_openai
+def test_litellm_chat_model_extra_headers(litellm_success_callback_calls):
+    """Test that provided extra_headers is passed to the litellm success callback."""
+    chat_model = LitellmChatModel("gpt-3.5-turbo", extra_headers={"x-auth-header": "123"})
+    assert chat_model.extra_headers == {"x-auth-header": "123"}
+    chat_model.complete(messages=[UserMessage("Say hello!")])
+    callback_call = litellm_success_callback_calls[0]
+    assert callback_call["kwargs"]["litellm_params"]["extra_headers"] == {"x-auth-header": "123"}
+
+
+@pytest.mark.litellm_openai
 def test_litellm_chat_model_metadata(litellm_success_callback_calls):
     """Test that provided metadata is passed to the litellm success callback."""
     chat_model = LitellmChatModel("gpt-4o", metadata={"foo": "bar"})

--- a/tests/chat_model/test_litellm_chat_model.py
+++ b/tests/chat_model/test_litellm_chat_model.py
@@ -49,14 +49,18 @@ def litellm_success_callback_calls() -> Iterator[list[dict[str, Any]]]:
     litellm.success_callback = original_success_callback
 
 
-@pytest.mark.litellm_openai
+@pytest.mark.litellm_ollama
 def test_litellm_chat_model_extra_headers(litellm_success_callback_calls):
     """Test that provided extra_headers is passed to the litellm success callback."""
-    chat_model = LitellmChatModel("gpt-3.5-turbo", extra_headers={"x-auth-header": "123"})
-    assert chat_model.extra_headers == {"x-auth-header": "123"}
+    chat_model = LitellmChatModel(
+        "ollama/deepseek-coder-v2", 
+        api_base="https://ollama.orianna.ai",
+        extra_headers={"cf-access-token": "..."},
+    )
+    assert chat_model.extra_headers == {"cf-access-token": "..."}
     chat_model.complete(messages=[UserMessage("Say hello!")])
     callback_call = litellm_success_callback_calls[0]
-    assert callback_call["kwargs"]["litellm_params"]["extra_headers"] == {"x-auth-header": "123"}
+    assert callback_call["kwargs"]["litellm_params"]["extra_headers"] == {"cf-access-token": "..."}
 
 
 @pytest.mark.litellm_openai


### PR DESCRIPTION
My ollama instance runs behind an reverse proxy (Cloudflare Access) which uses custom headers (cf-access-client-id / cf-access-client-secret or cf-access-token) to authenticate the user. I'm able to access my instance using litellm in the following way, but I'd like to switch to using magnetic.

```python
import litellm

response = litellm.completion(
    model="ollama/deepseek-coder-v2",
    messages=[{"content": "generate a simple sql query", "role": "user"}],
    api_base="...",
    extra_headers={"cf-access-token": "..."},
)

print(response)
```

closes #260