### PR TITLE
Parse function calling parameter description from the docstrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: # Show help for each of the Makefile recipes.
 	@pre-commit -V || echo 'Please install pre-commit: https://pre-commit.com/'
 
 .PHONY: install
-install: .uv .p  # Install the package, dependencies, and pre-commit for local developmentre-commit
+install: .uv  # Install the package, dependencies, and pre-commit for local development
 	uv sync --frozen
 	pre-commit install --install-hooks
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: # Show help for each of the Makefile recipes.
 	@pre-commit -V || echo 'Please install pre-commit: https://pre-commit.com/'
 
 .PHONY: install
-install: .uv  # Install the package, dependencies, and pre-commit for local development
+install: .uv .pre-commit # Install the package, dependencies, and pre-commit for local development
 	uv sync --frozen
 	pre-commit install --install-hooks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Seamlessly integrate LLMs as Python functions"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "docstring-parser>=0.16",
     "filetype>=1.2.0",
     "logfire-api>=0.1.0",
     "openai>=1.56.0",

--- a/src/magentic/chat_model/function_schema.py
+++ b/src/magentic/chat_model/function_schema.py
@@ -396,17 +396,15 @@ def parse_docstring(func: Callable[..., Any]) -> tuple[str | None, dict[str, str
         return None, {}
 
     # Pattern for Args/Parameters section
-    args_pattern = (
-        r"(\s*(?:Args|Parameters):(.*?))(?:Returns:|Raises:|Yields:|Examples:|$)"
-    )
+    args_pattern = r"(\s*(?:Args|Parameters):(.*?))(?:Returns:|Raises:|Yields:|Examples:|Example:|$)"
     args_match = re.search(args_pattern, docstring, re.DOTALL)
     main_desc = docstring
 
     param_descriptions: dict[str, str] = {}
     if args_match:
         args_section_content = args_match.group(2).strip()
-        # Pattern for each parameter (name: description)
-        param_pattern = r"^\s*([^\s:]+)\s*:\s*(.+?)(?=^\s*[^\s:]+\s*:|$)"
+        param_pattern = r"(?:^|\n)\s*([^\s:(]+)(?:\s*\([^)]+\))?\s*:\s*(.+?)(?=(?:\n\s*[^\s:(]+(?:\s*\([^)]+\))?\s*:|\Z))"
+
         param_matches = re.finditer(
             param_pattern, args_section_content, re.MULTILINE | re.DOTALL
         )

--- a/src/magentic/chat_model/function_schema.py
+++ b/src/magentic/chat_model/function_schema.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 import typing
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterable, Callable, Iterable
@@ -365,9 +366,11 @@ def create_model_from_function(func: Callable[..., Any]) -> type[BaseModel]:
         # **kwargs
         if param.kind is inspect.Parameter.VAR_KEYWORD:
             fields[param.name] = (
-                dict[str, param.annotation]  # type: ignore[name-defined]
-                if param.annotation != inspect._empty
-                else dict[str, Any],
+                (
+                    dict[str, param.annotation]  # type: ignore[name-defined]
+                    if param.annotation != inspect._empty
+                    else dict[str, Any]
+                ),
                 param.default if param.default != inspect._empty else {},
             )
             continue
@@ -379,12 +382,56 @@ def create_model_from_function(func: Callable[..., Any]) -> type[BaseModel]:
     return create_model("FuncModel", __config__=get_pydantic_config(func), **fields)
 
 
+def parse_docstring(func: Callable[..., Any]) -> tuple[str | None, dict[str, str]]:
+    """Parse a function's docstring to extract the main description and parameter descriptions.
+
+    Parameters:
+        func: The function whose docstring to parse
+
+    Returns:
+        A tuple containing (main_description, parameter_descriptions_dict)
+    """
+    docstring = inspect.getdoc(func)
+    if not docstring:
+        return None, {}
+
+    # Pattern for Args/Parameters section
+    args_pattern = (
+        r"(\s*(?:Args|Parameters):(.*?))(?:Returns:|Raises:|Yields:|Examples:|$)"
+    )
+    args_match = re.search(args_pattern, docstring, re.DOTALL)
+    main_desc = docstring
+
+    param_descriptions: dict[str, str] = {}
+    if args_match:
+        args_section_content = args_match.group(2).strip()
+        # Pattern for each parameter (name: description)
+        param_pattern = r"^\s*([^\s:]+)\s*:\s*(.+?)(?=^\s*[^\s:]+\s*:|$)"
+        param_matches = re.finditer(
+            param_pattern, args_section_content, re.MULTILINE | re.DOTALL
+        )
+
+        for match in param_matches:
+            param_name = match.group(1).strip()
+            param_desc = match.group(2).strip()
+            # Clean up any multi-line descriptions
+            param_desc = re.sub(r"\s+", " ", param_desc)
+            param_descriptions[param_name] = param_desc
+
+        # Remove the Args/Parameters section
+        args_section = args_match.group(1)
+        main_desc = main_desc.replace(args_section, "\n\n").strip()
+
+    return main_desc, param_descriptions
+
+
 class FunctionCallFunctionSchema(FunctionSchema[FunctionCall[T]], Generic[T]):
     """FunctionSchema for FunctionCall."""
 
     def __init__(self, func: Callable[..., T]):
         self._func = func
         self._model = create_model_from_function(func)
+        self._main_desc, self._param_descriptions = parse_docstring(func)
 
     @property
     def name(self) -> str:
@@ -392,11 +439,19 @@ class FunctionCallFunctionSchema(FunctionSchema[FunctionCall[T]], Generic[T]):
 
     @property
     def description(self) -> str | None:
-        return inspect.getdoc(self._func)
+        return self._main_desc
 
     @property
     def parameters(self) -> dict[str, Any]:
-        return json_schema(self._model)
+        schema = json_schema(self._model)
+
+        # Add descriptions to the properties from parsed docstring
+        if "properties" in schema and self._param_descriptions:
+            for param_name, param_desc in self._param_descriptions.items():
+                if param_name in schema["properties"]:
+                    schema["properties"][param_name]["description"] = param_desc
+
+        return schema
 
     @property
     def strict(self) -> bool | None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
@@ -622,6 +623,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/12/9c22a58c0b1e29271051222d8906257616da84135af9ed167c9e28f85cb3/docstring_parser-0.16.tar.gz", hash = "sha256:538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e", size = 26565 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl", hash = "sha256:bf0a1387354d3691d102edef7ec124f219ef639982d096e26e3b60aeffa90637", size = 36533 },
 ]
 
 [[package]]
@@ -1392,6 +1402,7 @@ name = "magentic"
 version = "0.39.2"
 source = { editable = "." }
 dependencies = [
+    { name = "docstring-parser" },
     { name = "filetype" },
     { name = "logfire-api" },
     { name = "openai" },
@@ -1443,6 +1454,7 @@ examples = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.41.0" },
+    { name = "docstring-parser", specifier = ">=0.16" },
     { name = "filetype", specifier = ">=1.2.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.41.12" },
     { name = "logfire-api", specifier = ">=0.1.0" },
@@ -1451,6 +1463,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
+provides-extras = ["anthropic", "litellm"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Magentic does not give "description" to function parameters. As seen in the prompt shared by Anthropic https://www.anthropic.com/engineering/swe-bench-sonnet, giving description to function parameter is a good practice.

This PR aims to automatically parse parameter description from the standard docstings of the function.

For example:

```
from magentic.chat_model.function_schema import get_function_schemas
from magentic.chat_model.openai_chat_model import BaseFunctionToolSchema

async def agent(test: str) -> str:
    """
    Agent function that processes a test string.
    
    Args:
        test (str): The test string to process
    
    Returns:
        A string result after processing
    """
    ...

BaseFunctionToolSchema(get_function_schemas([agent], [str])[0]).to_dict()
```

Gives:
```
{
  "type": "function",
  "function": {
    "name": "agent",
    "parameters": {
      "properties": {
        "test": {
          "title": "Test",
          "type": "string",
          "description": "The test string to process"
        }
      },
      "required": ["test"],
      "type": "object"
    },
    "description": "Agent function that processes a test string.\n\nReturns:\n    A string result after processing"
  }
}
```