### PR TITLE
feat: Add textwrap.dedent support to Message classes

### DIFF
--- a/src/magentic/chat_model/message.py
+++ b/src/magentic/chat_model/message.py
@@ -1,4 +1,5 @@
 import base64
+import textwrap
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Iterable, Sequence
 from functools import cached_property
@@ -122,11 +123,13 @@ class SystemMessage(Message[str]):
 
     role: Literal["system"] = "system"
 
-    def __init__(self, content: str, **data: Any):
+    def __init__(self, content: str, *, dedent: bool = True, **data: Any):
+        if dedent:
+            content = textwrap.dedent(content)
         super().__init__(content=content, **data)
 
     def format(self, **kwargs: Any) -> "SystemMessage":
-        return SystemMessage(self.content.format(**kwargs))
+        return SystemMessage(self.content.format(**kwargs), dedent=False)
 
 
 # Anthropic supports PDF: https://docs.anthropic.com/en/docs/build-with-claude/pdf-support
@@ -224,7 +227,11 @@ class UserMessage(Message[UserMessageContentT], Generic[UserMessageContentT]):
 
     role: Literal["user"] = "user"
 
-    def __init__(self, content: UserMessageContentT, **data: Any):
+    def __init__(
+        self, content: UserMessageContentT, *, dedent: bool = True, **data: Any
+    ):
+        if dedent and isinstance(content, str):
+            content = cast(UserMessageContentT, textwrap.dedent(content))
         super().__init__(content=content, **data)
 
     @overload
@@ -241,9 +248,12 @@ class UserMessage(Message[UserMessageContentT], Generic[UserMessageContentT]):
         **kwargs: Any,
     ) -> "UserMessage[StrT | Sequence[StrT2 | UserMessageContentBlockT | UserMessageContentBlockT2]]":
         if isinstance(self.content, str):
-            return UserMessage(self.content.format(**kwargs))
+            return UserMessage(self.content.format(**kwargs), dedent=False)
         if isinstance(self.content, Iterable):
-            return UserMessage([block.format(**kwargs) for block in self.content])  # type: ignore[misc]
+            return UserMessage(
+                [block.format(**kwargs) for block in self.content],  # type: ignore[misc]
+                dedent=False,
+            )
         msg = f"Unsupported content type: {type(self.content)}"
         raise ValueError(msg)
 

--- a/tests/chat_model/test_message.py
+++ b/tests/chat_model/test_message.py
@@ -283,3 +283,62 @@ def test_any_message():
         AssistantMessage("Hello"),
         ToolResultMessage(3, "unique_id"),
     ]
+
+
+def test_system_message_dedent():
+    """Test that SystemMessage dedents text content by default."""
+    message = SystemMessage("""\
+        A very long prompt
+        that is indented to be more readable.""")
+    assert (
+        message.content == "A very long prompt\nthat is indented to be more readable."
+    )
+
+
+def test_system_message_dedent_disabled():
+    """Test that SystemMessage preserves indentation when dedent=False."""
+    content = """\
+        A very long prompt
+        that is indented to be more readable."""
+    message = SystemMessage(content, dedent=False)
+    assert message.content == content
+
+
+def test_user_message_dedent():
+    """Test that UserMessage dedents text content by default."""
+    message = UserMessage("""\
+        A very long prompt
+        that is indented to be more readable.""")
+    assert (
+        message.content == "A very long prompt\nthat is indented to be more readable."
+    )
+
+
+def test_user_message_dedent_disabled():
+    """Test that UserMessage preserves indentation when dedent=False."""
+    content = """\
+        A very long prompt
+        that is indented to be more readable."""
+    message = UserMessage(content, dedent=False)
+    assert message.content == content
+
+
+def test_user_message_dedent_non_string_content():
+    """Test that UserMessage with non-string content is not affected by dedent."""
+    image_url = ImageUrl("https://example.com/image.png")
+    message = UserMessage([image_url])
+    assert message.content == [image_url]
+
+
+def test_system_message_format_preserves_no_dedent():
+    """Test that format() on SystemMessage does not re-dedent content."""
+    message = SystemMessage("Hello {x}")
+    formatted = message.format(x="world")
+    assert formatted.content == "Hello world"
+
+
+def test_user_message_format_preserves_no_dedent():
+    """Test that format() on UserMessage does not re-dedent content."""
+    message = UserMessage("Hello {x}")
+    formatted = message.format(x="world")
+    assert formatted.content == "Hello world"


### PR DESCRIPTION
## Summary
- Add `dedent` parameter (default `True`) to `SystemMessage` and `UserMessage` to automatically remove common leading whitespace from text content
- Uses Python's `textwrap.dedent()` for consistent whitespace handling
- Preserves original behavior when `dedent=False` is explicitly passed

## Test Plan
- Added unit tests for dedent functionality on both message types
- Verified `format()` method correctly passes `dedent=False` to avoid re-dedenting
- All existing tests pass

Fixes #431