### PR TITLE
feat: Parse function docstrings into parameter descriptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Seamlessly integrate LLMs as Python functions"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "docstring-parser>=0.15",
     "filetype>=1.2.0",
     "logfire-api>=0.1.0",
     "openai>=1.108.1",
@@ -64,6 +65,7 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = [
+    "docstring_parser",
     "filetype",
     "litellm",
     "litellm.utils",

--- a/src/magentic/chat_model/function_schema.py
+++ b/src/magentic/chat_model/function_schema.py
@@ -5,8 +5,10 @@ from collections.abc import AsyncIterable, Callable, Iterable
 from functools import singledispatch
 from typing import Any, Generic, TypeVar, cast, get_args, get_origin
 
+from docstring_parser import parse as parse_docstring
 from openai.types.shared_params import FunctionDefinition
 from pydantic import BaseModel, TypeAdapter, create_model
+from pydantic.fields import FieldInfo
 
 from magentic._pydantic import ConfigDict, get_pydantic_config, json_schema
 from magentic._streamed_response import AsyncStreamedResponse, StreamedResponse
@@ -345,9 +347,34 @@ class BaseModelFunctionSchema(FunctionSchema[BaseModelT], Generic[BaseModelT]):
         return value.model_dump_json()
 
 
+def _get_param_descriptions(func: Callable[..., Any]) -> dict[str, str]:
+    """Extract parameter descriptions from function docstring."""
+    docstring = inspect.getdoc(func)
+    if not docstring:
+        return {}
+
+    parsed = parse_docstring(docstring)
+    return {
+        param.arg_name: param.description
+        for param in parsed.params
+        if param.description
+    }
+
+
+def _has_field_description(annotation: Any) -> bool:
+    """Check if the annotation already has a Field with description."""
+    if get_origin(annotation) is not typing.Annotated:
+        return False
+    for arg in get_args(annotation):
+        if isinstance(arg, FieldInfo) and arg.description is not None:
+            return True
+    return False
+
+
 def create_model_from_function(func: Callable[..., Any]) -> type[BaseModel]:
     """Create a Pydantic model from a function signature."""
     # https://github.com/pydantic/pydantic/issues/3585#issuecomment-1002745763
+    param_descriptions = _get_param_descriptions(func)
     fields: dict[str, Any] = {}
     for param in inspect.signature(func).parameters.values():
         # *args
@@ -372,11 +399,43 @@ def create_model_from_function(func: Callable[..., Any]) -> type[BaseModel]:
             )
             continue
 
-        fields[param.name] = (
-            (param.annotation if param.annotation != inspect._empty else Any),
-            (param.default if param.default != inspect._empty else ...),
-        )
+        annotation = param.annotation if param.annotation != inspect._empty else Any
+        default = param.default if param.default != inspect._empty else ...
+
+        # Add description from docstring if not already specified via Field
+        if param.name in param_descriptions and not _has_field_description(annotation):
+            from pydantic import Field
+
+            fields[param.name] = (
+                annotation,
+                Field(default=default, description=param_descriptions[param.name]),
+            )
+        else:
+            fields[param.name] = (annotation, default)
+
     return create_model("FuncModel", __config__=get_pydantic_config(func), **fields)
+
+
+def _get_function_description(func: Callable[..., Any]) -> str | None:
+    """Get function description from docstring, excluding parameter descriptions."""
+    docstring = inspect.getdoc(func)
+    if not docstring:
+        return None
+
+    parsed = parse_docstring(docstring)
+
+    # Build description from short and long description only
+    parts = []
+    if parsed.short_description:
+        parts.append(parsed.short_description)
+    if parsed.long_description:
+        parts.append(parsed.long_description)
+
+    # Include returns section if present
+    if parsed.returns and parsed.returns.description:
+        parts.append(f"Returns:\n    {parsed.returns.description}")
+
+    return "\n\n".join(parts) if parts else None
 
 
 class FunctionCallFunctionSchema(FunctionSchema[FunctionCall[T]], Generic[T]):
@@ -392,7 +451,7 @@ class FunctionCallFunctionSchema(FunctionSchema[FunctionCall[T]], Generic[T]):
 
     @property
     def description(self) -> str | None:
-        return inspect.getdoc(self._func)
+        return _get_function_description(self._func)
 
     @property
     def parameters(self) -> dict[str, Any]:

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -919,3 +919,102 @@ def test_function_call_function_schema_serialize_invalid_args(
     """Invalid function arguments should serialize so LLM errors can be resubmitted."""
     serialized_args = FunctionCallFunctionSchema(function).serialize_args(args)
     assert json.loads(serialized_args) == json.loads(expected_args_str)
+
+
+def func_with_google_docstring(a: int, b: str) -> int:
+    """Calculate something.
+
+    This is a longer description that explains
+    what the function does.
+
+    Args:
+        a: The first number to process
+        b: The second parameter as a string
+
+    Returns:
+        The result of the calculation
+    """
+    return a
+
+
+def func_with_numpy_docstring(x: int, y: str) -> int:
+    """Calculate something.
+
+    Parameters
+    ----------
+    x : int
+        The first number to process
+    y : str
+        The second parameter as a string
+
+    Returns
+    -------
+    int
+        The result of the calculation
+    """
+    return x
+
+
+def func_with_field_override(
+    a: Annotated[int, Field(description="Field description takes priority")],
+    b: str,
+) -> int:
+    """Function with Field override.
+
+    Args:
+        a: This should be ignored because Field has description
+        b: This description should be used
+    """
+    return a
+
+
+def test_function_call_schema_google_docstring_params():
+    """Test that Google-style docstring parameter descriptions are parsed."""
+    schema = FunctionCallFunctionSchema(func_with_google_docstring)
+    params = schema.parameters
+
+    assert params["properties"]["a"].get("description") == "The first number to process"
+    assert (
+        params["properties"]["b"].get("description")
+        == "The second parameter as a string"
+    )
+
+
+def test_function_call_schema_numpy_docstring_params():
+    """Test that NumPy-style docstring parameter descriptions are parsed."""
+    schema = FunctionCallFunctionSchema(func_with_numpy_docstring)
+    params = schema.parameters
+
+    assert params["properties"]["x"].get("description") == "The first number to process"
+    assert (
+        params["properties"]["y"].get("description")
+        == "The second parameter as a string"
+    )
+
+
+def test_function_call_schema_field_description_takes_priority():
+    """Test that Field description takes priority over docstring."""
+    schema = FunctionCallFunctionSchema(func_with_field_override)
+    params = schema.parameters
+
+    assert (
+        params["properties"]["a"].get("description")
+        == "Field description takes priority"
+    )
+    assert (
+        params["properties"]["b"].get("description")
+        == "This description should be used"
+    )
+
+
+def test_function_call_schema_description_excludes_params():
+    """Test that function description excludes param section from docstring."""
+    schema = FunctionCallFunctionSchema(func_with_google_docstring)
+    description = schema.description
+
+    assert description is not None
+    assert "Calculate something" in description
+    assert "This is a longer description" in description
+    assert "Returns:\n    The result of the calculation" in description
+    assert "Args:" not in description
+    assert "The first number to process" not in description

--- a/uv.lock
+++ b/uv.lock
@@ -626,6 +626,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1393,6 +1402,7 @@ name = "magentic"
 version = "0.41.0"
 source = { editable = "." }
 dependencies = [
+    { name = "docstring-parser" },
     { name = "filetype" },
     { name = "logfire-api" },
     { name = "openai" },
@@ -1444,6 +1454,7 @@ examples = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.41.0" },
+    { name = "docstring-parser", specifier = ">=0.15" },
     { name = "filetype", specifier = ">=1.2.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.41.12" },
     { name = "logfire-api", specifier = ">=0.1.0" },


### PR DESCRIPTION
## Summary
- Add `docstring-parser` dependency for parsing Google/NumPy/ReST docstring styles
- Extract parameter descriptions from function docstrings and add them to the function schema
- Pydantic `Field` descriptions take priority over docstring descriptions
- Remove parameter section from function description to keep single source of truth

## Example

```python
def get_weather(location: str, unit: str = "celsius") -> str:
    """Get the current weather.

    Args:
        location: The city and country, e.g. "Tokyo, Japan"
        unit: Temperature unit, either "celsius" or "fahrenheit"

    Returns:
        Weather description string
    """
    ...
```

Now generates a function schema with parameter descriptions:
```json
{
  "name": "get_weather",
  "description": "Get the current weather.\n\nReturns:\n    Weather description string",
  "parameters": {
    "properties": {
      "location": {
        "type": "string",
        "description": "The city and country, e.g. \"Tokyo, Japan\""
      },
      "unit": {
        "type": "string", 
        "description": "Temperature unit, either \"celsius\" or \"fahrenheit\"",
        "default": "celsius"
      }
    }
  }
}
```

## Test Plan
- Added tests for Google-style docstring parsing
- Added tests for NumPy-style docstring parsing
- Added tests verifying Field description takes priority
- Added tests verifying description excludes param section
- All existing tests pass

Fixes #440