### PR TITLE
Add MiniMax as first-class LLM provider backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Seamlessly integrate Large Language Models into Python code. Use the `@prompt` a
 - [LLM-Assisted Retries] to improve LLM adherence to complex output schemas.
 - [Observability] using OpenTelemetry, with native [Pydantic Logfire integration].
 - [Type Annotations] to work nicely with linters and IDEs.
-- [Configuration] options for multiple LLM providers including OpenAI, Anthropic, and Ollama.
+- [Configuration] options for multiple LLM providers including OpenAI, Anthropic, MiniMax, and Ollama.
 - Many more features: [Chat Prompting], [Parallel Function Calling], [Vision], [Formatting], [Asyncio]...
 
 ## Installation
@@ -402,6 +402,18 @@ from magentic.chat_model.litellm_chat_model import LitellmChatModel
 model = LitellmChatModel("gpt-4o")
 ```
 
+### MiniMax
+
+This uses the `openai` Python package to query MiniMax models via their OpenAI-compatible API at `https://api.minimax.io/v1`. Available models include `MiniMax-M2.7` (latest, 1M context), `MiniMax-M2.5`, and `MiniMax-M2.5-highspeed` (204K context). Temperature values are automatically clamped to MiniMax's accepted range of (0, 1], and thinking tags from reasoning models are stripped from the output.
+
+No additional installation is required. Set the `MINIMAX_API_KEY` environment variable, then import the `MiniMaxChatModel` class.
+
+```python
+from magentic.chat_model.minimax_chat_model import MiniMaxChatModel
+
+model = MiniMaxChatModel("MiniMax-M2.7")
+```
+
 ### Mistral
 
 This uses the `openai` Python package with some small modifications to make the API queries compatible with the Mistral API. It supports all features of magentic. However tool calls (including structured outputs) are not streamed so are received all at once.
@@ -453,7 +465,7 @@ The following environment variables can be set.
 
 | Environment Variable           | Description                              | Example                      |
 | ------------------------------ | ---------------------------------------- | ---------------------------- |
-| MAGENTIC_BACKEND               | The package to use as the LLM backend    | anthropic / openai / litellm |
+| MAGENTIC_BACKEND               | The package to use as the LLM backend    | anthropic / minimax / openai |
 | MAGENTIC_ANTHROPIC_MODEL       | Anthropic model                          | claude-3-haiku-20240307      |
 | MAGENTIC_ANTHROPIC_API_KEY     | Anthropic API key to be used by magentic | sk-...                       |
 | MAGENTIC_ANTHROPIC_BASE_URL    | Base URL for an Anthropic-compatible API | http://localhost:8080        |
@@ -463,6 +475,12 @@ The following environment variables can be set.
 | MAGENTIC_LITELLM_API_BASE      | The base url to query                    | http://localhost:11434       |
 | MAGENTIC_LITELLM_MAX_TOKENS    | LiteLLM max number of generated tokens   | 1024                         |
 | MAGENTIC_LITELLM_TEMPERATURE   | LiteLLM temperature                      | 0.5                          |
+| MAGENTIC_MINIMAX_MODEL         | MiniMax model                            | MiniMax-M2.7                 |
+| MAGENTIC_MINIMAX_API_KEY       | MiniMax API key to be used by magentic   | eyJ...                       |
+| MAGENTIC_MINIMAX_BASE_URL      | Base URL for MiniMax API                 | https://api.minimax.io/v1    |
+| MAGENTIC_MINIMAX_MAX_TOKENS    | Max number of generated tokens           | 1024                         |
+| MAGENTIC_MINIMAX_SEED          | Seed for deterministic sampling          | 42                           |
+| MAGENTIC_MINIMAX_TEMPERATURE   | Temperature (clamped to 0-1)             | 0.5                          |
 | MAGENTIC_MISTRAL_MODEL         | Mistral model                            | mistral-large-latest         |
 | MAGENTIC_MISTRAL_API_KEY       | Mistral API key to be used by magentic   | XEG...                       |
 | MAGENTIC_MISTRAL_BASE_URL      | Base URL for an Mistral-compatible API   | http://localhost:8080        |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ markers = [
     "litellm_anthropic: Tests that query the Anthropic API via litellm. Requires the ANTHROPIC_API_KEY environment variable to be set.",
     "litellm_ollama: Tests that query Ollama via litellm. Requires ollama to be installed and running on localhost:11434.",
     "litellm_openai: Tests that query the OpenAI API via litellm. Requires the OPENAI_API_KEY environment variable to be set.",
+    "minimax: Tests that query the MiniMax API (via openai). Requires the MINIMAX_API_KEY environment variable to be set.",
     "mistral: Tests that query the Mistral API (via openai). Requires the MISTRAL_API_KEY environment variable to be set.",
     "openai: Tests that query the OpenAI API. Requires the OPENAI_API_KEY environment variable to be set.",
     "openai_gemini: Tests that query the Gemini API via openai. Requires the GEMINI_API_KEY environment variable to be set.",

--- a/src/magentic/backend.py
+++ b/src/magentic/backend.py
@@ -19,6 +19,17 @@ def get_chat_model() -> ChatModel:
                 max_tokens=settings.anthropic_max_tokens,
                 temperature=settings.anthropic_temperature,
             )
+        case Backend.MINIMAX:
+            from magentic.chat_model.minimax_chat_model import MiniMaxChatModel
+
+            return MiniMaxChatModel(
+                model=settings.minimax_model,
+                api_key=settings.minimax_api_key,
+                base_url=settings.minimax_base_url,
+                max_tokens=settings.minimax_max_tokens,
+                seed=settings.minimax_seed,
+                temperature=settings.minimax_temperature,
+            )
         case Backend.LITELLM:
             from magentic.chat_model.litellm_chat_model import LitellmChatModel
 

--- a/src/magentic/chat_model/minimax_chat_model.py
+++ b/src/magentic/chat_model/minimax_chat_model.py
@@ -30,10 +30,56 @@ from magentic.chat_model.stream import AsyncOutputStream, OutputStream
 
 _THINK_TAG_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
+# MiniMax ignores tool_choice (named/required/auto all behave the same).
+# A system message is required to force the model to call tools.
+_TOOL_USE_SYSTEM_MSG = {
+    "role": "system",
+    "content": (
+        "You MUST use the available tools to respond."
+        " Do NOT answer with plain text. Always call a tool."
+    ),
+}
+
 
 def _strip_think_tags(text: str) -> str:
     """Strip MiniMax thinking tags from model output."""
     return _THINK_TAG_RE.sub("", text)
+
+
+def _filter_content_chunks(
+    stream: Iterator[ChatCompletionChunk],
+) -> Iterator[ChatCompletionChunk]:
+    """Skip content-only chunks so ``OutputStream`` sees tool calls first.
+
+    MiniMax M2.7 always emits ``<think>...</think>`` reasoning and sometimes
+    explanatory text before producing tool-call deltas.  The base
+    ``OutputStream.__stream__`` exits its main loop when the first chunk is
+    neither ``is_content`` nor ``is_tool_call``.  By stripping content-only
+    chunks here we guarantee the first chunk reaching ``OutputStream``
+    carries a tool-call delta.
+    """
+    for chunk in stream:
+        if (
+            chunk.choices
+            and chunk.choices[0].delta.content
+            and not chunk.choices[0].delta.tool_calls
+        ):
+            continue
+        yield chunk
+
+
+async def _afilter_content_chunks(
+    stream: AsyncIterator[ChatCompletionChunk],
+) -> AsyncIterator[ChatCompletionChunk]:
+    """Async version of :func:`_filter_content_chunks`."""
+    async for chunk in stream:
+        if (
+            chunk.choices
+            and chunk.choices[0].delta.content
+            and not chunk.choices[0].delta.tool_calls
+        ):
+            continue
+        yield chunk
 
 
 class MiniMaxStreamParser(OpenaiStreamParser):
@@ -43,23 +89,14 @@ class MiniMaxStreamParser(OpenaiStreamParser):
     response.  These must be hidden from both ``is_content`` (so the
     ``OutputStream`` does not create a ``StreamedStr`` for them) and
     ``get_content`` (so think-tag text never leaks into the output).
-
-    When *tools_expected* is True, all content is skipped so that only
-    tool-call chunks are processed.  MiniMax often emits explanatory text
-    before calling tools, and that text must not be treated as content.
     """
 
-    def __init__(self, *, tools_expected: bool = False) -> None:
+    def __init__(self) -> None:
         super().__init__()
         self._in_think_block: bool = False
-        self._tools_expected: bool = tools_expected
 
     def is_content(self, item: ChatCompletionChunk) -> bool:
         if not (item.choices and item.choices[0].delta.content):
-            return False
-        # When tools are expected, skip all text content – it is just
-        # pre-tool-call commentary produced by the model.
-        if self._tools_expected:
             return False
         content = item.choices[0].delta.content
         if "<think>" in content:
@@ -119,12 +156,18 @@ class _MiniMaxOpenaiChatModel(OpenaiChatModel):
         tool_schemas: Sequence[BaseFunctionToolSchema[Any]],
         output_types: Iterable[type],
     ) -> str | openai.Omit:
-        """Create the tool choice argument."""
+        """Create the tool choice argument.
+
+        MiniMax ignores named tool choice and ``"required"``, so we always
+        use ``"auto"`` (when tools are present and string output is not
+        expected) and rely on a system-message prompt to steer the model
+        toward calling a tool.
+        """
         if contains_string_type(output_types):
             return openai.omit
-        if len(tool_schemas) == 1:
-            return tool_schemas[0].as_tool_choice()
-        return "required"
+        if tool_schemas:
+            return "auto"
+        return openai.omit
 
     def _get_parallel_tool_calls(
         self, *, tools_specified: bool, output_types: Iterable[type]
@@ -146,11 +189,17 @@ class _MiniMaxOpenaiChatModel(OpenaiChatModel):
         function_schemas = get_function_schemas(functions, output_types)
         tool_schemas = [BaseFunctionToolSchema(schema) for schema in function_schemas]
 
+        openai_messages = _add_missing_tool_calls_responses(
+            [message_to_openai_message(m) for m in messages]
+        )
+        # MiniMax ignores tool_choice; inject a system prompt to force tool use
+        tools_only = bool(tool_schemas) and not contains_string_type(output_types)
+        if tools_only:
+            openai_messages = [_TOOL_USE_SYSTEM_MSG, *openai_messages]
+
         response: Iterator[ChatCompletionChunk] = self._client.chat.completions.create(
             model=self.model,
-            messages=_add_missing_tool_calls_responses(
-                [message_to_openai_message(m) for m in messages]
-            ),
+            messages=openai_messages,
             max_tokens=_if_given(self.max_tokens),
             seed=_if_given(self.seed),
             stop=_if_given(stop),
@@ -165,10 +214,13 @@ class _MiniMaxOpenaiChatModel(OpenaiChatModel):
                 tools_specified=bool(tool_schemas), output_types=output_types
             ),
         )
+        # Strip pre-tool content so OutputStream sees tool-call chunks first
+        if tools_only:
+            response = _filter_content_chunks(response)
         stream = OutputStream(
             response,
             function_schemas=function_schemas,
-            parser=MiniMaxStreamParser(tools_expected=bool(tool_schemas)),
+            parser=MiniMaxStreamParser(),
             state=OpenaiStreamState(),
         )
         return AssistantMessage._with_usage(
@@ -190,13 +242,18 @@ class _MiniMaxOpenaiChatModel(OpenaiChatModel):
         function_schemas = get_async_function_schemas(functions, output_types)
         tool_schemas = [BaseFunctionToolSchema(schema) for schema in function_schemas]
 
+        openai_messages = _add_missing_tool_calls_responses(
+            [await async_message_to_openai_message(m) for m in messages]
+        )
+        tools_only = bool(tool_schemas) and not contains_string_type(output_types)
+        if tools_only:
+            openai_messages = [_TOOL_USE_SYSTEM_MSG, *openai_messages]
+
         response: AsyncIterator[
             ChatCompletionChunk
         ] = await self._async_client.chat.completions.create(
             model=self.model,
-            messages=_add_missing_tool_calls_responses(
-                [await async_message_to_openai_message(m) for m in messages]
-            ),
+            messages=openai_messages,
             max_tokens=_if_given(self.max_tokens),
             seed=_if_given(self.seed),
             stop=_if_given(stop),
@@ -211,10 +268,12 @@ class _MiniMaxOpenaiChatModel(OpenaiChatModel):
                 tools_specified=bool(tool_schemas), output_types=output_types
             ),
         )
+        if tools_only:
+            response = _afilter_content_chunks(response)
         stream = AsyncOutputStream(
             response,
             function_schemas=function_schemas,
-            parser=MiniMaxStreamParser(tools_expected=bool(tool_schemas)),
+            parser=MiniMaxStreamParser(),
             state=OpenaiStreamState(),
         )
         return AssistantMessage._with_usage(

--- a/src/magentic/chat_model/minimax_chat_model.py
+++ b/src/magentic/chat_model/minimax_chat_model.py
@@ -1,0 +1,315 @@
+import os
+import re
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Sequence
+from typing import Any, cast
+
+import openai
+from openai.types.chat import (
+    ChatCompletionChunk,
+    ChatCompletionStreamOptionsParam,
+)
+
+from magentic._parsing import contains_string_type
+from magentic.chat_model.base import ChatModel, OutputT, aparse_stream, parse_stream
+from magentic.chat_model.function_schema import (
+    get_async_function_schemas,
+    get_function_schemas,
+)
+from magentic.chat_model.message import AssistantMessage, Message
+from magentic.chat_model.openai_chat_model import (
+    BaseFunctionToolSchema,
+    OpenaiChatModel,
+    OpenaiStreamParser,
+    OpenaiStreamState,
+    _add_missing_tool_calls_responses,
+    _if_given,
+    async_message_to_openai_message,
+    message_to_openai_message,
+)
+from magentic.chat_model.stream import AsyncOutputStream, OutputStream
+
+_THINK_TAG_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+
+
+def _strip_think_tags(text: str) -> str:
+    """Strip MiniMax thinking tags from model output."""
+    return _THINK_TAG_RE.sub("", text)
+
+
+class MiniMaxStreamParser(OpenaiStreamParser):
+    """Stream parser that strips MiniMax thinking tags from content.
+
+    MiniMax models may emit ``<think>...</think>`` blocks before the actual
+    response.  These must be hidden from both ``is_content`` (so the
+    ``OutputStream`` does not create a ``StreamedStr`` for them) and
+    ``get_content`` (so think-tag text never leaks into the output).
+
+    When *tools_expected* is True, all content is skipped so that only
+    tool-call chunks are processed.  MiniMax often emits explanatory text
+    before calling tools, and that text must not be treated as content.
+    """
+
+    def __init__(self, *, tools_expected: bool = False) -> None:
+        super().__init__()
+        self._in_think_block: bool = False
+        self._tools_expected: bool = tools_expected
+
+    def is_content(self, item: ChatCompletionChunk) -> bool:
+        if not (item.choices and item.choices[0].delta.content):
+            return False
+        # When tools are expected, skip all text content – it is just
+        # pre-tool-call commentary produced by the model.
+        if self._tools_expected:
+            return False
+        content = item.choices[0].delta.content
+        if "<think>" in content:
+            self._in_think_block = True
+        if self._in_think_block:
+            if "</think>" in content:
+                self._in_think_block = False
+                # Only treat as content if there's text after the closing tag
+                after = content.split("</think>", 1)[1]
+                return bool(after.strip())
+            return False
+        return True
+
+    def get_content(self, item: ChatCompletionChunk) -> str | None:
+        if not (item.choices and item.choices[0].delta.content):
+            return None
+        content = item.choices[0].delta.content
+        # Strip any remaining think tags from the chunk
+        if "</think>" in content:
+            content = content.split("</think>", 1)[1]
+            return content if content else None
+        return content
+
+
+class _MiniMaxOpenaiChatModel(OpenaiChatModel):
+    """Modified OpenaiChatModel to be compatible with MiniMax API."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = "https://api.minimax.io/v1",
+        max_tokens: int | None = None,
+        seed: int | None = None,
+        temperature: float | None = None,
+    ):
+        # Clamp temperature to MiniMax's accepted range (0, 1]
+        if temperature is not None:
+            temperature = max(0.01, min(temperature, 1.0))
+
+        super().__init__(
+            model,
+            api_key=api_key,
+            base_url=base_url,
+            max_tokens=max_tokens,
+            seed=seed,
+            temperature=temperature,
+        )
+
+    def _get_stream_options(self) -> ChatCompletionStreamOptionsParam | openai.Omit:
+        return openai.omit
+
+    @staticmethod
+    def _get_tool_choice(  # type: ignore[override]
+        *,
+        tool_schemas: Sequence[BaseFunctionToolSchema[Any]],
+        output_types: Iterable[type],
+    ) -> str | openai.Omit:
+        """Create the tool choice argument."""
+        if contains_string_type(output_types):
+            return openai.omit
+        if len(tool_schemas) == 1:
+            return tool_schemas[0].as_tool_choice()
+        return "required"
+
+    def _get_parallel_tool_calls(
+        self, *, tools_specified: bool, output_types: Iterable[type]
+    ) -> bool | openai.Omit:
+        return openai.omit
+
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., Any]] | None = None,
+        output_types: Iterable[type[OutputT]] | None = None,
+        *,
+        stop: list[str] | None = None,
+    ) -> AssistantMessage[OutputT]:
+        """Request an LLM message."""
+        if output_types is None:
+            output_types = cast("Iterable[type[OutputT]]", [] if functions else [str])
+
+        function_schemas = get_function_schemas(functions, output_types)
+        tool_schemas = [BaseFunctionToolSchema(schema) for schema in function_schemas]
+
+        response: Iterator[ChatCompletionChunk] = self._client.chat.completions.create(
+            model=self.model,
+            messages=_add_missing_tool_calls_responses(
+                [message_to_openai_message(m) for m in messages]
+            ),
+            max_tokens=_if_given(self.max_tokens),
+            seed=_if_given(self.seed),
+            stop=_if_given(stop),
+            stream=True,
+            stream_options=self._get_stream_options(),
+            temperature=_if_given(self.temperature),
+            tools=[schema.to_dict() for schema in tool_schemas] or openai.omit,
+            tool_choice=self._get_tool_choice(
+                tool_schemas=tool_schemas, output_types=output_types
+            ),
+            parallel_tool_calls=self._get_parallel_tool_calls(
+                tools_specified=bool(tool_schemas), output_types=output_types
+            ),
+        )
+        stream = OutputStream(
+            response,
+            function_schemas=function_schemas,
+            parser=MiniMaxStreamParser(tools_expected=bool(tool_schemas)),
+            state=OpenaiStreamState(),
+        )
+        return AssistantMessage._with_usage(
+            parse_stream(stream, output_types), usage_ref=stream.usage_ref
+        )
+
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., Any]] | None = None,
+        output_types: Iterable[type[OutputT]] | None = None,
+        *,
+        stop: list[str] | None = None,
+    ) -> AssistantMessage[OutputT]:
+        """Async version of `complete`."""
+        if output_types is None:
+            output_types = [] if functions else cast("list[type[OutputT]]", [str])
+
+        function_schemas = get_async_function_schemas(functions, output_types)
+        tool_schemas = [BaseFunctionToolSchema(schema) for schema in function_schemas]
+
+        response: AsyncIterator[
+            ChatCompletionChunk
+        ] = await self._async_client.chat.completions.create(
+            model=self.model,
+            messages=_add_missing_tool_calls_responses(
+                [await async_message_to_openai_message(m) for m in messages]
+            ),
+            max_tokens=_if_given(self.max_tokens),
+            seed=_if_given(self.seed),
+            stop=_if_given(stop),
+            stream=True,
+            stream_options=self._get_stream_options(),
+            temperature=_if_given(self.temperature),
+            tools=[schema.to_dict() for schema in tool_schemas] or openai.omit,
+            tool_choice=self._get_tool_choice(
+                tool_schemas=tool_schemas, output_types=output_types
+            ),
+            parallel_tool_calls=self._get_parallel_tool_calls(
+                tools_specified=bool(tool_schemas), output_types=output_types
+            ),
+        )
+        stream = AsyncOutputStream(
+            response,
+            function_schemas=function_schemas,
+            parser=MiniMaxStreamParser(tools_expected=bool(tool_schemas)),
+            state=OpenaiStreamState(),
+        )
+        return AssistantMessage._with_usage(
+            await aparse_stream(stream, output_types), usage_ref=stream.usage_ref
+        )
+
+
+class MiniMaxChatModel(ChatModel):
+    """An LLM chat model for the MiniMax API.
+
+    Currently this uses the ``openai`` Python package. MiniMax provides an
+    OpenAI-compatible API at ``https://api.minimax.io/v1``. Available models
+    include ``MiniMax-M2.7`` and ``MiniMax-M2.5-highspeed``.
+
+    Temperature is automatically clamped to the MiniMax-accepted range of (0, 1].
+    Thinking tags (``<think>...</think>``) produced by reasoning models are stripped
+    from streamed output so they do not appear in the final response.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        max_tokens: int | None = None,
+        seed: int | None = None,
+        temperature: float | None = None,
+    ):
+        if not (api_key or os.getenv("MINIMAX_API_KEY")):
+            msg = (
+                "MINIMAX_API_KEY environment variable or api_key argument is required."
+            )
+            raise openai.OpenAIError(msg)
+        self._minimax_openai_chat_model = _MiniMaxOpenaiChatModel(
+            model,
+            api_key=api_key or os.getenv("MINIMAX_API_KEY"),
+            base_url=base_url or "https://api.minimax.io/v1",
+            max_tokens=max_tokens,
+            seed=seed,
+            temperature=temperature,
+        )
+
+    @property
+    def model(self) -> str:
+        return self._minimax_openai_chat_model.model
+
+    @property
+    def api_key(self) -> str | None:
+        return self._minimax_openai_chat_model.api_key
+
+    @property
+    def base_url(self) -> str | None:
+        return self._minimax_openai_chat_model.base_url
+
+    @property
+    def max_tokens(self) -> int | None:
+        return self._minimax_openai_chat_model.max_tokens
+
+    @property
+    def seed(self) -> int | None:
+        return self._minimax_openai_chat_model.seed
+
+    @property
+    def temperature(self) -> float | None:
+        return self._minimax_openai_chat_model.temperature
+
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., Any]] | None = None,
+        output_types: Iterable[type[OutputT]] | None = None,
+        *,
+        stop: list[str] | None = None,
+    ) -> AssistantMessage[OutputT]:
+        """Request an LLM message."""
+        return self._minimax_openai_chat_model.complete(
+            messages=messages,
+            functions=functions,
+            output_types=output_types,
+            stop=stop,
+        )
+
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., Any]] | None = None,
+        output_types: Iterable[type[OutputT]] | None = None,
+        *,
+        stop: list[str] | None = None,
+    ) -> AssistantMessage[OutputT]:
+        """Async version of `complete`."""
+        return await self._minimax_openai_chat_model.acomplete(
+            messages=messages,
+            functions=functions,
+            output_types=output_types,
+            stop=stop,
+        )

--- a/src/magentic/settings.py
+++ b/src/magentic/settings.py
@@ -7,6 +7,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Backend(Enum):
     ANTHROPIC = "anthropic"
     LITELLM = "litellm"
+    MINIMAX = "minimax"
     MISTRAL = "mistral"
     OPENAI = "openai"
 
@@ -26,6 +27,13 @@ class Settings(BaseSettings):
     litellm_api_base: str | None = None
     litellm_max_tokens: int | None = None
     litellm_temperature: float | None = None
+
+    minimax_model: str = "MiniMax-M2.7"
+    minimax_api_key: str | None = None
+    minimax_base_url: str | None = None
+    minimax_max_tokens: int | None = None
+    minimax_seed: int | None = None
+    minimax_temperature: float | None = None
 
     mistral_model: str = "mistral-large-latest"
     mistral_api_key: str | None = None

--- a/tests/chat_model/test_minimax_chat_model.py
+++ b/tests/chat_model/test_minimax_chat_model.py
@@ -1,0 +1,353 @@
+import os
+
+import openai
+import pytest
+from pydantic import BaseModel
+
+from magentic.chat_model.message import (
+    AssistantMessage,
+    SystemMessage,
+    Usage,
+    UserMessage,
+)
+from magentic.chat_model.minimax_chat_model import (
+    MiniMaxChatModel,
+    MiniMaxStreamParser,
+    _MiniMaxOpenaiChatModel,
+    _strip_think_tags,
+)
+from magentic.function_call import FunctionCall
+from magentic.streaming import AsyncStreamedStr, StreamedStr
+
+
+# --- Unit tests (no API calls) ---
+
+
+def test_strip_think_tags_empty():
+    assert _strip_think_tags("Hello world") == "Hello world"
+
+
+def test_strip_think_tags_simple():
+    assert _strip_think_tags("<think>reasoning here</think>Hello") == "Hello"
+
+
+def test_strip_think_tags_multiline():
+    text = "<think>\nLet me think...\nStep 1\nStep 2\n</think>\nThe answer is 42."
+    assert _strip_think_tags(text) == "The answer is 42."
+
+
+def test_strip_think_tags_multiple():
+    text = "<think>first</think>Hello <think>second</think>World"
+    assert _strip_think_tags(text) == "Hello World"
+
+
+def test_strip_think_tags_trailing_whitespace():
+    assert _strip_think_tags("<think>x</think> Hello") == "Hello"
+
+
+def test_minimax_stream_parser_no_think_tags():
+    """MiniMaxStreamParser passes through normal content."""
+    from unittest.mock import MagicMock
+
+    parser = MiniMaxStreamParser()
+    chunk = MagicMock()
+    chunk.choices = [MagicMock()]
+    chunk.choices[0].delta.content = "Hello world"
+    result = parser.get_content(chunk)
+    assert result == "Hello world"
+
+
+def test_minimax_stream_parser_no_content():
+    """MiniMaxStreamParser returns None when no content."""
+    from unittest.mock import MagicMock
+
+    parser = MiniMaxStreamParser()
+    chunk = MagicMock()
+    chunk.choices = [MagicMock()]
+    chunk.choices[0].delta.content = None
+    result = parser.get_content(chunk)
+    assert result is None
+
+
+def test_minimax_stream_parser_empty_choices():
+    """MiniMaxStreamParser returns None when choices is empty."""
+    from unittest.mock import MagicMock
+
+    parser = MiniMaxStreamParser()
+    chunk = MagicMock()
+    chunk.choices = []
+    result = parser.get_content(chunk)
+    assert result is None
+
+
+def test_minimax_stream_parser_tools_expected_skips_content():
+    """MiniMaxStreamParser skips content when tools_expected=True."""
+    from unittest.mock import MagicMock
+
+    parser = MiniMaxStreamParser(tools_expected=True)
+    chunk = MagicMock()
+    chunk.choices = [MagicMock()]
+    chunk.choices[0].delta.content = "I'll use the tool"
+    assert parser.is_content(chunk) is False
+
+
+def test_minimax_stream_parser_think_tags_skipped():
+    """MiniMaxStreamParser skips think-tag-only content."""
+    from unittest.mock import MagicMock
+
+    parser = MiniMaxStreamParser()
+    chunk = MagicMock()
+    chunk.choices = [MagicMock()]
+    chunk.choices[0].delta.content = "<think>reasoning</think>"
+    assert parser.is_content(chunk) is False
+
+
+def test_minimax_chat_model_api_key_required(monkeypatch):
+    """MiniMaxChatModel raises error when no API key is provided."""
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    with pytest.raises(openai.OpenAIError, match="MINIMAX_API_KEY"):
+        MiniMaxChatModel("MiniMax-M2.7")
+
+
+def test_minimax_chat_model_api_key_from_env(monkeypatch):
+    """MiniMaxChatModel uses MINIMAX_API_KEY env var."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key-123")
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    assert chat_model.api_key == "test-key-123"
+
+
+def test_minimax_chat_model_api_key_explicit(monkeypatch):
+    """MiniMaxChatModel uses explicit api_key over env var."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+    chat_model = MiniMaxChatModel("MiniMax-M2.7", api_key="explicit-key")
+    assert chat_model.api_key == "explicit-key"
+
+
+def test_minimax_chat_model_default_base_url(monkeypatch):
+    """MiniMaxChatModel defaults to MiniMax API base URL."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    assert chat_model.base_url == "https://api.minimax.io/v1"
+
+
+def test_minimax_chat_model_custom_base_url(monkeypatch):
+    """MiniMaxChatModel accepts custom base URL."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    chat_model = MiniMaxChatModel(
+        "MiniMax-M2.7", base_url="http://localhost:8080"
+    )
+    assert chat_model.base_url == "http://localhost:8080"
+
+
+def test_minimax_chat_model_properties(monkeypatch):
+    """MiniMaxChatModel exposes all configuration properties."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    chat_model = MiniMaxChatModel(
+        "MiniMax-M2.7",
+        max_tokens=512,
+        seed=42,
+        temperature=0.7,
+    )
+    assert chat_model.model == "MiniMax-M2.7"
+    assert chat_model.max_tokens == 512
+    assert chat_model.seed == 42
+    assert chat_model.temperature == 0.7
+
+
+def test_minimax_temperature_clamping_high(monkeypatch):
+    """Temperature > 1.0 is clamped to 1.0."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    chat_model = MiniMaxChatModel("MiniMax-M2.7", temperature=2.0)
+    assert chat_model.temperature == 1.0
+
+
+def test_minimax_temperature_clamping_low(monkeypatch):
+    """Temperature <= 0 is clamped to 0.01."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    chat_model = MiniMaxChatModel("MiniMax-M2.7", temperature=0.0)
+    assert chat_model.temperature == 0.01
+
+
+def test_minimax_temperature_clamping_negative(monkeypatch):
+    """Negative temperature is clamped to 0.01."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    chat_model = MiniMaxChatModel("MiniMax-M2.7", temperature=-1.0)
+    assert chat_model.temperature == 0.01
+
+
+def test_minimax_temperature_none(monkeypatch):
+    """Temperature=None is passed through as-is."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    chat_model = MiniMaxChatModel("MiniMax-M2.7", temperature=None)
+    assert chat_model.temperature is None
+
+
+def test_minimax_temperature_in_range(monkeypatch):
+    """Temperature within (0, 1] is not modified."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    chat_model = MiniMaxChatModel("MiniMax-M2.7", temperature=0.5)
+    assert chat_model.temperature == 0.5
+
+
+def test_minimax_context_manager(monkeypatch):
+    """MiniMaxChatModel works as a context manager."""
+    from magentic.backend import get_chat_model
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    with chat_model:
+        assert get_chat_model() is chat_model
+
+
+# --- Integration tests (require MINIMAX_API_KEY) ---
+
+
+@pytest.mark.parametrize(
+    ("prompt", "output_types", "expected_output_type"),
+    [
+        ("Say hello!", [str], str),
+        ("Return True", [bool], bool),
+        ("Return the numbers 1 to 5", [list[int]], list),
+        ("List three fruits", [list[str]], list),
+    ],
+)
+@pytest.mark.minimax
+def test_minimax_chat_model_complete(prompt, output_types, expected_output_type):
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = chat_model.complete(
+        messages=[UserMessage(prompt)], output_types=output_types
+    )
+    assert isinstance(message.content, expected_output_type)
+
+
+@pytest.mark.minimax
+def test_minimax_chat_model_complete_usage():
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = chat_model.complete(
+        messages=[UserMessage("Say hello!")], output_types=[StreamedStr]
+    )
+    str(message.content)  # Finish the stream
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.minimax
+def test_minimax_chat_model_complete_usage_structured_output():
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = chat_model.complete(
+        messages=[UserMessage("Count to 5")], output_types=[list[int]]
+    )
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.minimax
+def test_minimax_chat_model_complete_function_call():
+    def plus(a: int, b: int) -> int:
+        """Sum two numbers."""
+        return a + b
+
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = chat_model.complete(
+        messages=[UserMessage("Use the tool to sum 1 and 2")],
+        functions=[plus],
+        output_types=[FunctionCall[int]],
+    )
+    assert isinstance(message.content, FunctionCall)
+
+
+@pytest.mark.minimax
+def test_minimax_chat_model_few_shot_prompt():
+    class Quote(BaseModel):
+        quote: str
+        character: str
+
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = chat_model.complete(
+        messages=[
+            SystemMessage("You are a movie buff."),
+            UserMessage("What is your favorite quote from Harry Potter?"),
+            AssistantMessage(
+                Quote(
+                    quote="It does not do to dwell on dreams and forget to live.",
+                    character="Albus Dumbledore",
+                )
+            ),
+            AssistantMessage("."),
+            UserMessage("What is your favorite quote from {movie}?"),
+        ],
+        output_types=[Quote],
+    )
+    assert isinstance(message.content, Quote)
+
+
+@pytest.mark.minimax
+def test_minimax_chat_model_complete_pydantic_model():
+    class CapitalCity(BaseModel):
+        capital: str
+        country: str
+
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = chat_model.complete(
+        messages=[UserMessage("What is the capital of Ireland?")],
+        output_types=[CapitalCity],
+    )
+    assert isinstance(message.content, CapitalCity)
+
+
+@pytest.mark.parametrize(
+    ("prompt", "output_types", "expected_output_type"),
+    [
+        ("Say hello!", [str], str),
+        ("Return True", [bool], bool),
+        ("Return the numbers 1 to 5", [list[int]], list),
+        ("List three fruits", [list[str]], list),
+    ],
+)
+@pytest.mark.minimax
+async def test_minimax_chat_model_acomplete(prompt, output_types, expected_output_type):
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = await chat_model.acomplete(
+        messages=[UserMessage(prompt)], output_types=output_types
+    )
+    assert isinstance(message.content, expected_output_type)
+
+
+@pytest.mark.minimax
+async def test_minimax_chat_model_acomplete_usage():
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = await chat_model.acomplete(
+        messages=[UserMessage("Say hello!")], output_types=[AsyncStreamedStr]
+    )
+    await message.content.to_string()  # Finish the stream
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.minimax
+async def test_minimax_chat_model_acomplete_usage_structured_output():
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = await chat_model.acomplete(
+        messages=[UserMessage("Count to 5")], output_types=[list[int]]
+    )
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.minimax
+async def test_minimax_chat_model_acomplete_function_call():
+    def plus(a: int, b: int) -> int:
+        """Sum two numbers."""
+        return a + b
+
+    chat_model = MiniMaxChatModel("MiniMax-M2.7")
+    message = await chat_model.acomplete(
+        messages=[UserMessage("Use the tool to sum 1 and 2")],
+        functions=[plus],
+        output_types=[FunctionCall[int]],
+    )
+    assert isinstance(message.content, FunctionCall)

--- a/tests/chat_model/test_minimax_chat_model.py
+++ b/tests/chat_model/test_minimax_chat_model.py
@@ -14,6 +14,7 @@ from magentic.chat_model.minimax_chat_model import (
     MiniMaxChatModel,
     MiniMaxStreamParser,
     _MiniMaxOpenaiChatModel,
+    _filter_content_chunks,
     _strip_think_tags,
 )
 from magentic.function_call import FunctionCall
@@ -80,15 +81,28 @@ def test_minimax_stream_parser_empty_choices():
     assert result is None
 
 
-def test_minimax_stream_parser_tools_expected_skips_content():
-    """MiniMaxStreamParser skips content when tools_expected=True."""
+def test_filter_content_chunks():
+    """_filter_content_chunks drops content-only chunks."""
     from unittest.mock import MagicMock
 
-    parser = MiniMaxStreamParser(tools_expected=True)
-    chunk = MagicMock()
-    chunk.choices = [MagicMock()]
-    chunk.choices[0].delta.content = "I'll use the tool"
-    assert parser.is_content(chunk) is False
+    def make_chunk(content=None, tool_calls=None):
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = content
+        chunk.choices[0].delta.tool_calls = tool_calls
+        return chunk
+
+    chunks = [
+        make_chunk(content="<think>reasoning</think>"),
+        make_chunk(content="some text"),
+        make_chunk(tool_calls=[MagicMock()]),
+        make_chunk(content=None),
+    ]
+    result = list(_filter_content_chunks(iter(chunks)))
+    # Only tool-call chunk and no-content chunk should remain
+    assert len(result) == 2
+    assert result[0].choices[0].delta.tool_calls is not None
+    assert result[1].choices[0].delta.content is None
 
 
 def test_minimax_stream_parser_think_tags_skipped():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ def pytest_collection_modifyitems(
         "litellm_anthropic",
         "litellm_ollama",
         "litellm_openai",
+        "minimax",
         "mistral",
         "openai",
         "openai_gemini",

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4,6 +4,7 @@ from magentic.backend import get_chat_model
 from magentic.chat_model.anthropic_chat_model import AnthropicChatModel
 from magentic.chat_model.litellm_chat_model import LitellmChatModel
 from magentic.chat_model.message import AssistantMessage, UserMessage
+from magentic.chat_model.minimax_chat_model import MiniMaxChatModel
 from magentic.chat_model.mistral_chat_model import MistralChatModel
 from magentic.chat_model.openai_chat_model import OpenaiChatModel
 
@@ -22,6 +23,24 @@ def test_backend_anthropic_chat_model(monkeypatch):
     assert chat_model.base_url == "http://localhost:8080"
     assert chat_model.max_tokens == 10
     assert chat_model.temperature == 2
+
+
+def test_backend_minimax_chat_model(monkeypatch):
+    monkeypatch.setenv("MAGENTIC_BACKEND", "minimax")
+    monkeypatch.setenv("MAGENTIC_MINIMAX_MODEL", "MiniMax-M2.7")
+    monkeypatch.setenv("MAGENTIC_MINIMAX_API_KEY", "sk-1234567890")
+    monkeypatch.setenv("MAGENTIC_MINIMAX_BASE_URL", "http://localhost:8080")
+    monkeypatch.setenv("MAGENTIC_MINIMAX_MAX_TOKENS", "1024")
+    monkeypatch.setenv("MAGENTIC_MINIMAX_SEED", "42")
+    monkeypatch.setenv("MAGENTIC_MINIMAX_TEMPERATURE", "0.5")
+    chat_model = get_chat_model()
+    assert isinstance(chat_model, MiniMaxChatModel)
+    assert chat_model.model == "MiniMax-M2.7"
+    assert chat_model.api_key == "sk-1234567890"
+    assert chat_model.base_url == "http://localhost:8080"
+    assert chat_model.max_tokens == 1024
+    assert chat_model.seed == 42
+    assert chat_model.temperature == 0.5
 
 
 def test_backend_mistral_chat_model(monkeypatch):


### PR DESCRIPTION
## Summary

Adds **MiniMax** as a new chat model backend for magentic, alongside OpenAI, Anthropic, Mistral and LiteLLM.

MiniMax provides an OpenAI-compatible API at `https://api.minimax.io/v1` with models including `MiniMax-M2.7` and `MiniMax-M2.5-highspeed`.

### Key changes

- **`MiniMaxChatModel`** — public facade following the existing provider pattern (`MistralChatModel`, etc.)
- **`_MiniMaxOpenaiChatModel`** — internal wrapper extending `OpenaiChatModel` with MiniMax-specific adaptations:
  - Temperature clamping to MiniMax's accepted range `(0, 1]`
  - Disables `stream_options` and `parallel_tool_calls` (unsupported)
  - Injects a tool-use system prompt for structured output (MiniMax ignores `tool_choice`)
  - Filters pre-tool content chunks so `OutputStream` processes tool calls correctly
- **`MiniMaxStreamParser`** — strips `<think>...</think>` reasoning blocks that MiniMax M2.7 always emits
- **Backend integration** — `Backend.MINIMAX` enum value, `MAGENTIC_MINIMAX_*` env vars, `get_chat_model()` dispatch
- **22 unit tests + 16 integration tests** covering string/bool/list/pydantic/function-call output, streaming, async, usage tracking, few-shot prompts

### Files changed (8 files, ~400 additions)

| File | Description |
|------|-------------|
| `src/magentic/chat_model/minimax_chat_model.py` | New provider implementation |
| `src/magentic/settings.py` | `Backend.MINIMAX` enum + settings |
| `src/magentic/backend.py` | `get_chat_model()` dispatch case |
| `tests/chat_model/test_minimax_chat_model.py` | Unit + integration tests |
| `tests/test_backend.py` | Backend configuration test |
| `tests/conftest.py` | `minimax` marker registration |
| `pyproject.toml` | pytest marker |
| `README.md` | Documentation |

## Test plan

- [x] All 22 unit tests pass (no API key required)
- [x] All integration tests pass against live MiniMax API:
  - [x] String output with think-tag stripping
  - [x] Structured output (pydantic models, `list[int]`, `bool`)
  - [x] Function calls
  - [x] Streaming usage tracking
  - [x] Async variants
- [x] Backend env var configuration test passes
- [x] Existing test suite unaffected