### PR TITLE
Add store and metadata support to OpenaiChatModel

### DIFF
--- a/src/magentic/chat_model/openai_chat_model.py
+++ b/src/magentic/chat_model/openai_chat_model.py
@@ -389,6 +389,8 @@ class OpenaiChatModel(ChatModel):
         temperature: float | None = None,
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         verbosity: Literal["low", "medium", "high"] | None = None,
+        store: bool | None = None,
+        metadata: dict[str, str] | None = None,
     ):
         self._model = model
         self._api_key = api_key
@@ -400,6 +402,8 @@ class OpenaiChatModel(ChatModel):
         self._temperature = temperature
         self._reasoning_effort = reasoning_effort
         self._verbosity = verbosity
+        self._store = store
+        self._metadata = metadata
 
         match api_type:
             case "openai":
@@ -456,6 +460,14 @@ class OpenaiChatModel(ChatModel):
     @property
     def verbosity(self) -> Literal["low", "medium", "high"] | None:
         return self._verbosity
+
+    @property
+    def store(self) -> bool | None:
+        return self._store
+
+    @property
+    def metadata(self) -> dict[str, str] | None:
+        return self._metadata
 
     def _get_stream_options(self) -> ChatCompletionStreamOptionsParam | openai.Omit:
         if self.api_type == "azure":
@@ -514,6 +526,8 @@ class OpenaiChatModel(ChatModel):
             stream=True,
             stream_options=self._get_stream_options(),
             temperature=_if_given(self.temperature),
+            store=_if_given(self.store),
+            metadata=_if_given(self.metadata),
             reasoning_effort=_if_given(self.reasoning_effort),
             verbosity=_if_given(self.verbosity),
             tools=[schema.to_dict() for schema in tool_schemas] or openai.omit,
@@ -565,6 +579,8 @@ class OpenaiChatModel(ChatModel):
             temperature=_if_given(self.temperature),
             reasoning_effort=_if_given(self.reasoning_effort),
             verbosity=_if_given(self.verbosity),
+            store=_if_given(self.store),
+            metadata=_if_given(self.metadata),
             tools=[schema.to_dict() for schema in tool_schemas] or openai.omit,
             tool_choice=self._get_tool_choice(
                 tool_schemas=tool_schemas, output_types=output_types

--- a/tests/chat_model/test_openai_chat_model.py
+++ b/tests/chat_model/test_openai_chat_model.py
@@ -284,6 +284,16 @@ def test_openai_chat_model_max_completion_tokens_property():
     assert chat_model.max_completion_tokens == 100
 
 
+def test_openai_chat_model_store_property():
+    chat_model = OpenaiChatModel("gpt-4o", store=True)
+    assert chat_model.store is True
+
+
+def test_openai_chat_model_metadata_property():
+    chat_model = OpenaiChatModel("gpt-4o", metadata={"source": "test"})
+    assert chat_model.metadata == {"source": "test"}
+
+
 @pytest.mark.openai
 def test_openai_chat_model_complete_seed():
     chat_model = OpenaiChatModel("gpt-4o", seed=42)


### PR DESCRIPTION
## Summary

Add support for `store` and `metadata` in `OpenaiChatModel`.

## Changes

* add `store` and `metadata` parameters to `OpenaiChatModel`
* add `store` and `metadata` properties
* pass both through in `complete()` and `acomplete()`
* add property tests for both fields

## Testing

* `uv run pytest tests/chat_model/test_openai_chat_model.py -k "store_property or metadata_property"`
* `uv run pytest tests/chat_model/test_openai_chat_model.py -k "max_completion_tokens_property or store_property or metadata_property"`

## Notes

This PR only adds the core `store`/`metadata` support and property tests.
It does not yet add automatic prompt-function metadata injection.
