### PR TITLE
feat: add Requesty chat model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ markers = [
     "openai_ollama: Tests that query Ollama via openai. Requires ollama to be installed and running on localhost:11434.",
     "openai_xai: Tests that query xAI via openai. Requires the XAI_API_KEY environment variable to be set.",
     "openrouter: Tests that query the OpenRouter API. Requires the OPENROUTER_API_KEY environment variable to be set.",
+    "requesty: Tests that query the Requesty API. Requires the REQUESTY_API_KEY environment variable to be set.",
 ]
 
 [tool.ruff]

--- a/src/magentic/chat_model/requesty_chat_model.py
+++ b/src/magentic/chat_model/requesty_chat_model.py
@@ -1,0 +1,414 @@
+import os
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Sequence
+from typing import Any, Literal, cast
+
+import openai
+from openai.types.chat import (
+    ChatCompletionChunk,
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionStreamOptionsParam,
+)
+
+from magentic._parsing import contains_parallel_function_call_type, contains_string_type
+from magentic.chat_model.base import ChatModel, OutputT, aparse_stream, parse_stream
+from magentic.chat_model.function_schema import (
+    get_async_function_schemas,
+    get_function_schemas,
+)
+from magentic.chat_model.message import AssistantMessage, ContentT, Message, Usage
+from magentic.chat_model.openai_chat_model import (
+    BaseFunctionToolSchema,
+    OpenaiChatModel,
+    OpenaiStreamParser,
+    OpenaiStreamState,
+    _add_missing_tool_calls_responses,
+    _if_given,
+    async_message_to_openai_message,
+    message_to_openai_message,
+)
+from magentic.chat_model.stream import AsyncOutputStream, OutputStream
+
+
+class RequestyStreamState(OpenaiStreamState):
+    """State for Requesty stream parsing."""
+
+    reasoning: str
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reasoning = ""
+
+    def update(self, item: ChatCompletionChunk) -> None:
+        super().update(item)
+        if (
+            item.choices
+            and hasattr(item.choices[0].delta, "reasoning")
+            and item.choices[0].delta.reasoning
+        ):
+            self.reasoning += item.choices[0].delta.reasoning
+
+
+class RequestyAssistantMessage(AssistantMessage[ContentT]):
+    """An assistant message from Requesty that includes reasoning tokens."""
+
+    reasoning: str = ""
+
+    def __init__(self, content: ContentT, reasoning: str = "", **data: Any):
+        super().__init__(content=content, **data)
+        self.reasoning = reasoning
+
+    @classmethod
+    def _with_usage(
+        cls,
+        content: ContentT,  # type: ignore[misc]
+        usage_ref: list[Usage],
+        reasoning: str = "",
+    ) -> "RequestyAssistantMessage[ContentT]":
+        """Create a message with usage statistics."""
+        message = cls(content=content, reasoning=reasoning)
+        message._usage_ref = usage_ref
+        return message
+
+
+class _RequestyOpenaiChatModel(OpenaiChatModel):
+    """Modified OpenaiChatModel to be compatible with Requesty API."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = "https://router.requesty.ai/v1",
+        max_tokens: int | None = None,
+        seed: int | None = None,
+        temperature: float | None = None,
+        # Routing options
+        route: Literal["fallback"] | None = None,
+        models: list[str] | None = None,
+        # Reasoner model options
+        reasoning_effort: Literal["low", "medium", "high"] | None = None,
+        reasoning_exclude: bool | None = None,
+        # Provider options
+        provider_order: list[str] | None = None,
+        allow_fallbacks: bool | None = None,
+        data_collection: Literal["allow", "deny"] | None = None,
+        provider_only: list[str] | None = None,
+        provider_ignore: list[str] | None = None,
+        quantizations: list[str] | None = None,
+        provider_sort: Literal["price", "throughput", "latency"] | None = None,
+        max_price: dict[str, float] | None = None,
+    ):
+        super().__init__(
+            model,
+            api_key=api_key,
+            base_url=base_url,
+            max_tokens=max_tokens,
+            seed=seed,
+            temperature=temperature,
+        )
+        self._route = route
+        self._models = models
+        self._reasoning_effort = reasoning_effort
+        self._reasoning_exclude = reasoning_exclude
+        # Provider options
+        self._provider_order = provider_order
+        self._allow_fallbacks = allow_fallbacks
+        self._data_collection = data_collection
+        self._provider_only = provider_only
+        self._provider_ignore = provider_ignore
+        self._quantizations = quantizations
+        self._provider_sort = provider_sort
+        self._max_price = max_price
+
+    def _get_stream_options(self) -> ChatCompletionStreamOptionsParam | openai.Omit:
+        return {"include_usage": True}
+
+    @staticmethod
+    def _get_tool_choice(
+        *,
+        tool_schemas: Sequence[BaseFunctionToolSchema[Any]],
+        output_types: Iterable[type],
+    ) -> (
+        Literal["none", "auto", "required"]
+        | openai.Omit
+        | ChatCompletionNamedToolChoiceParam
+    ):
+        if contains_string_type(output_types):
+            return openai.omit
+        if len(tool_schemas) == 1:
+            return tool_schemas[0].as_tool_choice()
+        return "required"
+
+    def _get_parallel_tool_calls(
+        self, *, tools_specified: bool, output_types: Iterable[type]
+    ) -> bool | openai.Omit:
+        if not tools_specified:
+            return openai.omit
+        if contains_parallel_function_call_type(output_types):
+            return openai.omit
+        return False
+
+    def _get_extra_body(self) -> dict[str, Any] | None:
+        """Get extra body parameters for Requesty API."""
+        extra_body: dict[str, Any] = {}
+        if self._route:
+            extra_body["route"] = self._route
+        if self._models:
+            extra_body["models"] = self._models
+
+        # Build provider object
+        provider: dict[str, Any] = {}
+        if self._provider_order:
+            provider["order"] = self._provider_order
+        if self._allow_fallbacks:
+            provider["allow_fallbacks"] = True
+        if self._data_collection:
+            provider["data_collection"] = self._data_collection
+        if self._provider_only:
+            provider["only"] = self._provider_only
+        if self._provider_ignore:
+            provider["ignore"] = self._provider_ignore
+        if self._quantizations:
+            provider["quantizations"] = self._quantizations
+        if self._provider_sort:
+            provider["sort"] = self._provider_sort
+        if self._max_price:
+            provider["max_price"] = self._max_price
+
+        if provider:
+            extra_body["provider"] = provider
+
+        # Build reasoning object
+        reasoning: dict[str, Any] = {}
+        if self._reasoning_effort:
+            reasoning["effort"] = self._reasoning_effort
+        if self._reasoning_exclude is not None:
+            reasoning["exclude"] = self._reasoning_exclude
+        if reasoning:
+            extra_body["reasoning"] = reasoning
+
+        return extra_body if extra_body else None
+
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., Any]] | None = None,
+        output_types: Iterable[type[OutputT]] | None = None,
+        *,
+        stop: list[str] | None = None,
+    ) -> RequestyAssistantMessage[OutputT]:
+        """Request an LLM message."""
+        if output_types is None:
+            output_types = cast("Iterable[type[OutputT]]", [] if functions else [str])
+
+        function_schemas = get_function_schemas(functions, output_types)
+        tool_schemas = [BaseFunctionToolSchema(schema) for schema in function_schemas]
+
+        response: Iterator[ChatCompletionChunk] = self._client.chat.completions.create(
+            model=self.model,
+            messages=_add_missing_tool_calls_responses(
+                [message_to_openai_message(m) for m in messages]
+            ),
+            max_tokens=_if_given(self.max_tokens),
+            seed=_if_given(self.seed),
+            stop=_if_given(stop),
+            stream=True,
+            stream_options=self._get_stream_options(),
+            temperature=_if_given(self.temperature),
+            tools=[schema.to_dict() for schema in tool_schemas] or openai.omit,
+            tool_choice=self._get_tool_choice(
+                tool_schemas=tool_schemas, output_types=output_types
+            ),
+            parallel_tool_calls=self._get_parallel_tool_calls(
+                tools_specified=bool(tool_schemas), output_types=output_types
+            ),
+            extra_body=self._get_extra_body(),
+        )
+        stream = OutputStream(
+            response,
+            function_schemas=function_schemas,
+            parser=OpenaiStreamParser(),
+            state=RequestyStreamState(),
+        )
+        return RequestyAssistantMessage._with_usage(
+            parse_stream(stream, output_types),
+            usage_ref=stream.usage_ref,
+            reasoning=stream._state.reasoning if stream._state.reasoning else "",  # type: ignore[attr-defined]
+        )
+
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., Any]] | None = None,
+        output_types: Iterable[type[OutputT]] | None = None,
+        *,
+        stop: list[str] | None = None,
+    ) -> RequestyAssistantMessage[OutputT]:
+        """Async version of `complete`."""
+        if output_types is None:
+            output_types = [] if functions else cast("list[type[OutputT]]", [str])
+
+        function_schemas = get_async_function_schemas(functions, output_types)
+        tool_schemas = [BaseFunctionToolSchema(schema) for schema in function_schemas]
+
+        response: AsyncIterator[
+            ChatCompletionChunk
+        ] = await self._async_client.chat.completions.create(
+            model=self.model,
+            messages=_add_missing_tool_calls_responses(
+                [await async_message_to_openai_message(m) for m in messages]
+            ),
+            max_tokens=_if_given(self.max_tokens),
+            seed=_if_given(self.seed),
+            stop=_if_given(stop),
+            stream=True,
+            stream_options=self._get_stream_options(),
+            temperature=_if_given(self.temperature),
+            tools=[schema.to_dict() for schema in tool_schemas] or openai.omit,
+            tool_choice=self._get_tool_choice(
+                tool_schemas=tool_schemas, output_types=output_types
+            ),
+            parallel_tool_calls=self._get_parallel_tool_calls(
+                tools_specified=bool(tool_schemas), output_types=output_types
+            ),
+            extra_body=self._get_extra_body(),
+        )
+        stream = AsyncOutputStream(
+            response,
+            function_schemas=function_schemas,
+            parser=OpenaiStreamParser(),
+            state=RequestyStreamState(),
+        )
+        return RequestyAssistantMessage._with_usage(
+            await aparse_stream(stream, output_types),
+            usage_ref=stream.usage_ref,
+            reasoning=stream._state.reasoning if stream._state.reasoning else "",  # type: ignore[attr-defined]
+        )
+
+
+class RequestyChatModel(ChatModel):
+    """An LLM chat model that uses Requesty's API via the `openai` python package."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = "https://router.requesty.ai/v1",
+        max_tokens: int | None = None,
+        seed: int | None = None,
+        temperature: float | None = None,
+        # Routing options
+        route: Literal["fallback"] | None = None,
+        models: list[str] | None = None,
+        # Reasoner model options
+        reasoning_effort: Literal["low", "medium", "high"] | None = None,
+        reasoning_exclude: bool | None = None,
+        # Provider options
+        provider_order: list[str] | None = None,
+        allow_fallbacks: bool | None = None,
+        data_collection: Literal["allow", "deny"] | None = None,
+        provider_only: list[str] | None = None,
+        provider_ignore: list[str] | None = None,
+        quantizations: list[str] | None = None,
+        provider_sort: Literal["price", "throughput", "latency"] | None = None,
+        max_price: dict[str, float] | None = None,
+    ):
+        if not (api_key or os.getenv("REQUESTY_API_KEY")):
+            exception_string = "REQUESTY_API_KEY variable or api_key required."
+            raise openai.OpenAIError(exception_string)
+        self._requesty_openai_chat_model = _RequestyOpenaiChatModel(
+            model,
+            api_key=api_key or os.getenv("REQUESTY_API_KEY"),
+            base_url=base_url,
+            max_tokens=max_tokens,
+            seed=seed,
+            temperature=temperature,
+            route=route,
+            models=models,
+            reasoning_effort=reasoning_effort,
+            reasoning_exclude=reasoning_exclude,
+            provider_order=provider_order,
+            allow_fallbacks=allow_fallbacks,
+            data_collection=data_collection,
+            provider_only=provider_only,
+            provider_ignore=provider_ignore,
+            quantizations=quantizations,
+            provider_sort=provider_sort,
+            max_price=max_price,
+        )
+
+    def _get_extra_body(self) -> dict[str, Any] | None:
+        """Get extra body parameters for Requesty API."""
+        return self._requesty_openai_chat_model._get_extra_body()
+
+    @property
+    def model(self) -> str:
+        return self._requesty_openai_chat_model.model
+
+    @property
+    def api_key(self) -> str | None:
+        return self._requesty_openai_chat_model.api_key
+
+    @property
+    def base_url(self) -> str | None:
+        return self._requesty_openai_chat_model.base_url
+
+    @property
+    def max_tokens(self) -> int | None:
+        return self._requesty_openai_chat_model.max_tokens
+
+    @property
+    def seed(self) -> int | None:
+        return self._requesty_openai_chat_model.seed
+
+    @property
+    def temperature(self) -> float | None:
+        return self._requesty_openai_chat_model.temperature
+
+    @property
+    def route(self) -> Literal["fallback"] | None:
+        return self._requesty_openai_chat_model._route
+
+    @property
+    def models(self) -> list[str] | None:
+        return self._requesty_openai_chat_model._models
+
+    @property
+    def reasoning(self) -> dict[str, Any] | None:
+        return {
+            "effort": self._requesty_openai_chat_model._reasoning_effort,
+            "exclude": self._requesty_openai_chat_model._reasoning_exclude,
+        }
+
+    def complete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., Any]] | None = None,
+        output_types: Iterable[type[OutputT]] | None = None,
+        *,
+        stop: list[str] | None = None,
+    ) -> RequestyAssistantMessage[OutputT]:
+        """Request an LLM message."""
+        return self._requesty_openai_chat_model.complete(
+            messages=messages,
+            functions=functions,
+            output_types=output_types,
+            stop=stop,
+        )
+
+    async def acomplete(
+        self,
+        messages: Iterable[Message[Any]],
+        functions: Iterable[Callable[..., Any]] | None = None,
+        output_types: Iterable[type[OutputT]] | None = None,
+        *,
+        stop: list[str] | None = None,
+    ) -> RequestyAssistantMessage[OutputT]:
+        """Async version of `complete`."""
+        return await self._requesty_openai_chat_model.acomplete(
+            messages=messages,
+            functions=functions,
+            output_types=output_types,
+            stop=stop,
+        )

--- a/tests/chat_model/test_requesty_chat_model.py
+++ b/tests/chat_model/test_requesty_chat_model.py
@@ -1,0 +1,271 @@
+import os
+from typing import Annotated
+
+import openai
+import pytest
+from pydantic import AfterValidator, BaseModel
+
+from magentic._pydantic import ConfigDict, with_config
+from magentic._streamed_response import AsyncStreamedResponse, StreamedResponse
+from magentic.chat_model.base import ToolSchemaParseError
+from magentic.chat_model.message import ImageBytes, Message, Usage, UserMessage
+from magentic.chat_model.requesty_chat_model import RequestyChatModel
+from magentic.function_call import FunctionCall
+from magentic.streaming import AsyncStreamedStr, StreamedStr
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_api_key(monkeypatch):
+    requesty_api_key = os.environ["REQUESTY_API_KEY"]
+    monkeypatch.delenv("REQUESTY_API_KEY")
+
+    with pytest.raises(openai.OpenAIError):
+        chat_model = RequestyChatModel("deepseek/deepseek-chat")
+
+    chat_model = RequestyChatModel("deepseek/deepseek-chat", api_key=requesty_api_key)
+    message = chat_model.complete(messages=[UserMessage("Say hello!")])
+    assert isinstance(message.content, str)
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_base_url():
+    chat_model = RequestyChatModel(
+        "deepseek/deepseek-chat", base_url="https://router.requesty.ai/v1"
+    )
+    message = chat_model.complete(messages=[UserMessage("Say hello!")])
+    assert isinstance(message.content, str)
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_seed():
+    chat_model = RequestyChatModel("deepseek/deepseek-chat", seed=42)
+    message1 = chat_model.complete(messages=[UserMessage("Say hello!")])
+    message2 = chat_model.complete(messages=[UserMessage("Say hello!")])
+    # Check that both responses are greetings
+    assert any(
+        greeting in message1.content.lower() for greeting in ["hello", "hi", "hey"]
+    )
+    assert any(
+        greeting in message2.content.lower() for greeting in ["hello", "hi", "hey"]
+    )
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_streamed_response():
+    def get_weather(location: str) -> None:
+        """Get the weather for a location."""
+
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    message = chat_model.complete(
+        messages=[UserMessage("Tell me your favorite city. Then get its weather.")],
+        functions=[get_weather],
+        output_types=[StreamedResponse],
+    )
+    assert isinstance(message.content, StreamedResponse)
+    response_items = list(message.content)
+    assert len(response_items) == 2
+    streamed_str, function_call = response_items
+    assert isinstance(streamed_str, StreamedStr)
+    assert len(streamed_str.to_string()) > 1  # Check StreamedStr was cached
+    assert isinstance(function_call, FunctionCall)
+    assert function_call() is None  # Check FunctionCall is successfully called
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_pydantic_model_openai_strict():
+    class CapitalCity(BaseModel):
+        model_config = ConfigDict(openai_strict=True)
+        capital: str
+        country: str
+
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    message = chat_model.complete(
+        messages=[UserMessage("What is the capital of Ireland?")],
+        output_types=[CapitalCity],
+    )
+    assert isinstance(message.content, CapitalCity)
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_function_call_openai_strict():
+    @with_config(ConfigDict(openai_strict=True))
+    def plus(a: int, b: int) -> int:
+        """Sum two numbers."""
+        return a + b
+
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    message = chat_model.complete(
+        messages=[UserMessage("Use the tool to sum 1 and 2")],
+        functions=[plus],
+        output_types=[FunctionCall[int]],
+    )
+    assert isinstance(message.content, FunctionCall)
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_usage():
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    message = chat_model.complete(
+        messages=[UserMessage("Say hello!")], output_types=[StreamedStr]
+    )
+    str(message.content)  # Finish the stream
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_usage_structured_output():
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    message = chat_model.complete(
+        messages=[UserMessage("Count to 5. Tool call please.")],
+        output_types=[list[int]],
+    )
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_no_structured_output_error():
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    message: Message[int | bool] = chat_model.complete(
+        messages=[UserMessage("What is 2+2? Integer please.")],
+        output_types=[int, bool],
+    )
+    assert isinstance(message.content, int | bool)
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_raises_tool_schema_parse_error():
+    def raise_error(v):
+        raise ValueError(v)
+
+    class Test(BaseModel):
+        value: Annotated[int, AfterValidator(raise_error)]
+
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    with pytest.raises(ToolSchemaParseError):
+        chat_model.complete(
+            messages=[UserMessage("Return a test value of 42.")],
+            output_types=[Test],
+        )
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_complete_image_bytes(image_bytes_jpg):
+    chat_model = RequestyChatModel("openai/gpt-4o-mini")
+    message = chat_model.complete(
+        messages=[
+            UserMessage(
+                ("Describe this image in one word.", ImageBytes(image_bytes_jpg))
+            )
+        ]
+    )
+    assert isinstance(message.content, str)
+
+
+@pytest.mark.requesty
+async def test_requesty_chat_model_acomplete_async_streamed_response():
+    def get_weather(location: str) -> None:
+        """Get the weather for a location."""
+
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    message = await chat_model.acomplete(
+        messages=[UserMessage("Tell me your favorite city. Then get its weather.")],
+        functions=[get_weather],
+        output_types=[AsyncStreamedResponse],
+    )
+    assert isinstance(message.content, AsyncStreamedResponse)
+    response_items = [x async for x in message.content]
+    assert len(response_items) == 2
+    streamed_str, function_call = response_items
+    assert isinstance(streamed_str, AsyncStreamedStr)
+    assert len(await streamed_str.to_string()) > 1  # Check AsyncStreamedStr was cached
+    assert isinstance(function_call, FunctionCall)
+    assert function_call() is None  # Check FunctionCall is successfully called
+
+
+@pytest.mark.requesty
+async def test_requesty_chat_model_acomplete_usage():
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    message = await chat_model.acomplete(
+        messages=[UserMessage("Say hello!")], output_types=[AsyncStreamedStr]
+    )
+    await message.content.to_string()  # Finish the stream
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.requesty
+async def test_requesty_chat_model_acomplete_usage_structured_output():
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    message = await chat_model.acomplete(
+        messages=[UserMessage("Count to 5")], output_types=[list[int]]
+    )
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0
+
+
+@pytest.mark.requesty
+async def test_requesty_chat_model_acomplete_raises_tool_schema_parse_error():
+    def raise_error(v):
+        raise ValueError(v)
+
+    class Test(BaseModel):
+        value: Annotated[int, AfterValidator(raise_error)]
+
+    chat_model = RequestyChatModel("deepseek/deepseek-chat")
+    with pytest.raises(ToolSchemaParseError):
+        await chat_model.acomplete(
+            messages=[UserMessage("Return a test value of 42.")],
+            output_types=[Test],
+        )
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_extra_body():
+    chat_model = RequestyChatModel(
+        "deepseek/deepseek-chat",
+        route="fallback",
+        models=["anthropic/claude-3-opus"],
+        reasoning_effort="low",
+        reasoning_exclude=False,
+        provider_only=["Novita"],
+    )
+    assert chat_model._get_extra_body() == {
+        "route": "fallback",
+        "models": ["anthropic/claude-3-opus"],
+        "provider": {"only": ["Novita"]},
+        "reasoning": {"effort": "low", "exclude": False},
+    }
+
+
+@pytest.mark.requesty
+def test_requesty_chat_model_reasoning_tokens():
+    chat_model = RequestyChatModel(
+        "deepseek/deepseek-reasoner",
+        reasoning_effort="low",
+        reasoning_exclude=False,
+    )
+    message = chat_model.complete(
+        messages=[UserMessage("Tell me a joke. Make it catchy.")],
+        output_types=[str],
+    )
+
+    # Verify response content
+    assert isinstance(message.content, str)
+    assert len(message.content) > 0
+
+    # Verify reasoning tokens are present in the response
+    assert hasattr(message, "reasoning")
+    assert message.reasoning is not None
+    assert isinstance(message.reasoning, str)
+    assert len(message.reasoning) > 0
+
+    # Verify usage stats are present
+    assert isinstance(message.usage, Usage)
+    assert message.usage.input_tokens > 0
+    assert message.usage.output_tokens > 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,7 @@ def pytest_collection_modifyitems(
         "openai_ollama",
         "openai_xai",
         "openrouter",
+        "requesty",
     ]
     for item in items:
         # Apply vcr marker to all LLM tests


### PR DESCRIPTION
## Summary

Adds a `RequestyChatModel` for [Requesty](https://router.requesty.ai), an OpenAI-compatible LLM router. Since Requesty is OpenAI-compatible and supports the same `extra_body` routing passthrough (provider / models / route / reasoning) as OpenRouter, this is a faithful structural mirror of the existing `OpenRouterChatModel` — same routing kwargs, same reasoning-token streaming behavior, same public wrapper shape.

Only the brand specifics differ:
- Base URL default: `https://router.requesty.ai/v1`
- API key env var: `REQUESTY_API_KEY`
- Model naming uses the same `provider/model` scheme (e.g. `openai/gpt-4o-mini`, `deepseek/deepseek-chat`)

## Usage

```python
from magentic.chat_model.requesty_chat_model import RequestyChatModel
from magentic.chat_model.message import UserMessage

# Reads REQUESTY_API_KEY from the environment (or pass api_key=...)
chat_model = RequestyChatModel("openai/gpt-4o-mini")
message = chat_model.complete(messages=[UserMessage("Say hello!")])
print(message.content)
```

All the OpenRouter-style routing/reasoning kwargs are supported identically:

```python
chat_model = RequestyChatModel(
    "deepseek/deepseek-chat",
    route="fallback",
    models=["anthropic/claude-3-opus"],
    reasoning_effort="low",
    provider_only=["Novita"],
)
```

## Changes

- `src/magentic/chat_model/requesty_chat_model.py` — new chat model (mirror of `openrouter_chat_model.py`): `RequestyStreamState`, `RequestyAssistantMessage`, `_RequestyOpenaiChatModel`, `RequestyChatModel`.
- `tests/chat_model/test_requesty_chat_model.py` — tests mirroring the OpenRouter test file, all marked `@pytest.mark.requesty` (network/VCR-gated, opt-in by default exactly like the `openrouter` tests).
- `pyproject.toml` — registered the `requesty` pytest marker.
- `tests/conftest.py` — added `requesty` to the `llm_markers` list so the VCR marker is auto-applied.

## Tests / lint

- `pytest tests/chat_model/test_requesty_chat_model.py::test_requesty_chat_model_extra_body` → **passed** (the offline test asserting `_get_extra_body()` builds the expected routing dict).
- Construction checks: `RequestyChatModel("openai/gpt-4o-mini")` constructs with `base_url == "https://router.requesty.ai/v1"`; with no key + no `api_key` it raises `openai.OpenAIError`.
- `ruff check` and `ruff format --check` on the new files → clean.
- `mypy` on the new module → no issues.

## Disclosure

I work at Requesty. Happy to adjust scope/naming or close if out of scope.
